### PR TITLE
Bluemix object storage fixes

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -393,7 +393,8 @@ module Fog
                                           :headers => {'Content-Type' => 'application/json'},
                                           :body    => Fog::JSON.encode(request_body),
                                           :method  => 'POST',
-                                          :path    => path
+                                          :path    => path,
+                                          :omit_default_port => true
                                       })
         @@token_cache[{body: request_body, path: path}] = response, Time.now + 30 # 30-second TTL, enough for most requests
       end

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -6,7 +6,7 @@ module Fog
       requires   :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_type, :openstack_service_name,
-                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_tenant, :openstack_tenant_id, :openstack_userid,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
                  :openstack_endpoint_type,


### PR DESCRIPTION
 * Fix 500 due to port presence in Host header for bluemix object storage
 * Recognize userid as argument