### PR TITLE
Added some testing jobs and descriptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,23 +20,6 @@ CollectionMethods:
     reduce: inject
 CyclomaticComplexity:
   Severity: refactor
-GlobalVars:
-  AllowedVariables:
-  # Loggers
-  - $audit_log
-  - $api_log
-  - $aws_log
-  - $fog_log
-  - $log
-  - $miq_ae_logger
-  - $policy_log
-  - $rails_log
-  - $rhevm_log
-  - $kube_log
-  - $scvmm_log
-  - $vim_log
-  # In Automate methods
-  - $evm
 FormatString:
   EnforcedStyle: percent
 HashSyntax:
@@ -64,10 +47,6 @@ TrivialAccessors:
 #
 # Enabled/Disabled
 #
-AllCops:
-  Exclude:
-    - config/toolbar_strings.rb
-    - gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
 ClassAndModuleChildren:
   Enabled: false
 DefEndAlignment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,122 @@
+#
+# Overrides
+#
+AbcSize:
+  Severity: refactor
+AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+BlockNesting:
+  Severity: refactor
+ClassLength:
+  Severity: refactor
+ClassCheck:
+  EnforcedStyle: kind_of?
+CollectionMethods:
+  PreferredMethods:
+    find: detect
+    find_all: select
+    map: collect
+    reduce: inject
+CyclomaticComplexity:
+  Severity: refactor
+GlobalVars:
+  AllowedVariables:
+  # Loggers
+  - $audit_log
+  - $api_log
+  - $aws_log
+  - $fog_log
+  - $log
+  - $miq_ae_logger
+  - $policy_log
+  - $rails_log
+  - $rhevm_log
+  - $kube_log
+  - $scvmm_log
+  - $vim_log
+  # In Automate methods
+  - $evm
+FormatString:
+  EnforcedStyle: percent
+HashSyntax:
+  EnforcedStyle: hash_rockets
+LineLength:
+  Max: 120
+  Severity: refactor
+MethodLength:
+  Max: 25
+  Severity: refactor
+ParameterLists:
+  Severity: refactor
+PerceivedComplexity:
+  Severity: refactor
+RedundantReturn:
+  AllowMultipleReturnValues: true
+SignalException:
+  EnforcedStyle: only_raise
+SingleLineMethods:
+  AllowIfMethodIsEmpty: false
+SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+TrivialAccessors:
+  AllowPredicates: true
+#
+# Enabled/Disabled
+#
+AllCops:
+  Exclude:
+    - config/toolbar_strings.rb
+    - gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
+ClassAndModuleChildren:
+  Enabled: false
+DefEndAlignment:
+  AutoCorrect: true
+Documentation:
+  Enabled: false
+Encoding:
+  Enabled: false
+EndAlignment:
+  AutoCorrect: true
+ExtraSpacing:
+  AutoCorrect: false # https://github.com/bbatsov/rubocop/issues/2280
+FindEach:
+  Enabled: false
+GuardClause:
+  Enabled: false
+IfUnlessModifier:
+  Enabled: false
+NumericLiterals:
+  AutoCorrect: false
+ParallelAssignment:
+  Enabled: false
+PerlBackrefs:
+  Enabled: false
+ReadWriteAttribute:
+  AutoCorrect: false
+RescueModifier:
+  AutoCorrect: false
+SingleLineBlockParams:
+  Enabled: false
+SpaceBeforeFirstArg:
+  Enabled: false
+SpecialGlobalVars:
+  AutoCorrect: false
+StringLiterals:
+  Enabled: false
+StringLiteralsInInterpolation:
+  Enabled: false
+TrailingCommaInLiteral:
+  Enabled: false
+WhileUntilModifier:
+  Enabled: false
+WordArray:
+  AutoCorrect: false
+
+ClassAndModuleCamelCase:
+  Exclude:
+    - lib/miq_automation_engine/service_models/*.rb
+FileName:
+  Exclude:
+    - lib/miq_automation_engine/service_models/*.rb
+    - config/toolbar_strings.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,11 +91,3 @@ WhileUntilModifier:
   Enabled: false
 WordArray:
   AutoCorrect: false
-
-ClassAndModuleCamelCase:
-  Exclude:
-    - lib/miq_automation_engine/service_models/*.rb
-FileName:
-  Exclude:
-    - lib/miq_automation_engine/service_models/*.rb
-    - config/toolbar_strings.rb

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,11 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
 
 task :default => :test
 
+desc 'Run fog-openstack unit tests'
 mock = ENV['FOG_MOCK'] || 'true'
 task :test do
   sh("export FOG_MOCK=#{mock} && bundle exec shindont")

--- a/fog-openstack.gemspec
+++ b/fog-openstack.gemspec
@@ -19,15 +19,16 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake',    '~> 10.0'
-  spec.add_development_dependency 'shindo',  '~> 0.3'
-  spec.add_development_dependency 'rubyzip', '~> 0.9.9'
-  spec.add_development_dependency "mime-types"
-  spec.add_development_dependency "mime-types-data"
-
   spec.add_dependency 'fog-core',  '>= 1.35'
   spec.add_dependency 'fog-json',  '>= 1.0'
   spec.add_dependency 'fog-xml',   '>= 0.1'
   spec.add_dependency 'ipaddress', '>= 0.8'
+
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency "mime-types"
+  spec.add_development_dependency "mime-types-data"
+  spec.add_development_dependency 'rake',    '~> 10.0'
+  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubyzip', '~> 0.9.9'
+  spec.add_development_dependency 'shindo',  '~> 0.3'
 end


### PR DESCRIPTION
- Added a description for `rake test`
- moved the order of the dependancies
- added rubocop

Now if we decide to use rubocop, running without a `.rubocop.yml` it
comes back with

```
773 files inspected, 12455 offenses detected
```

I suggest we decide on a `.rubocop.yml` before we start doing anything
large with this Gem.