### PR TITLE
Trigger coveralls after Travis finishes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ matrix:
     gemfile: Gemfile
   allow_failures:
   - rvm: jruby-head
+after_success:
+  - coveralls


### PR DESCRIPTION
Looks like we need this additional step to kick Coveralls off when Travis finishes its test run.