### PR TITLE
Disable email notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ matrix:
   - rvm: jruby-head
 after_success:
   - coveralls
+notifications:
+  email: false


### PR DESCRIPTION
I can't find any other way to disable build notification emails in Travis.

If anyone wants to receive them, read this and put in a PR: https://docs.travis-ci.com/user/notifications/#Email-notifications