### PR TITLE
Bluemix object storage fixes

### DIFF
--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -6,10 +6,10 @@ module Fog
       requires   :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_type, :openstack_service_name,
-                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_tenant, :openstack_tenant_id, :openstack_userid,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
-                 :openstack_endpoint_type,
+                 :openstack_endpoint_type, :openstack_auth_omit_default_port,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,


### PR DESCRIPTION
 * Fix 500 due to port presence in Host header for bluemix object storage
 * Recognize userid as argument

This is #1 with making port omitting optional.