### PR TITLE
add volume type and metadata options in create_volume

### DIFF
--- a/lib/fog/openstack/requests/compute/create_volume.rb
+++ b/lib/fog/openstack/requests/compute/create_volume.rb
@@ -24,10 +24,10 @@ module Fog
           end
 
           request(
-            body: Fog::JSON.encode(data),
-            expects: [200, 202],
-            method: 'POST',
-            path: 'os-volumes'
+            :body    => Fog::JSON.encode(data),
+            :expects => [200, 202],
+            :method  => 'POST',
+            :path    => 'os-volumes'
           )
         end
       end

--- a/lib/fog/openstack/requests/compute/create_volume.rb
+++ b/lib/fog/openstack/requests/compute/create_volume.rb
@@ -37,21 +37,19 @@ module Fog
         def create_volume(name, description, size, options = {})
           response = Excon::Response.new
           response.status = 202
-          data = {
-            'id'                  => Fog::Mock.random_numbers(2),
-            'displayName'         => name,
-            'displayDescription'  => description,
-            'size'                => size,
-            'status'              => 'creating',
-            'snapshotId'          => options[:snapshot_id],
-            'volumeType'          => options[:volume_type] || 'None',
-            'availabilityZone'    => options[:availability_zone] || 'nova',
-            'createdAt'           => Time.now.strftime('%FT%T.%6N'),
-            'attachments'         => [],
-            'metadata'            => options[:metadata] || {}
+          data = {'id' => Fog::Mock.random_numbers(2),
+                  'displayName' => name,
+                  'displayDescription' => description,
+                  'size' => size,
+                  'status' => 'creating',
+                  'snapshotId' => options[:snapshot_id],
+                  'volumeType' => options[:volume_type] || 'None',
+                  'availabilityZone' => options[:availability_zone] || 'nova',
+                  'createdAt' => Time.now.strftime('%FT%T.%6N'),
+                  'attachments' => [], 'metadata' => options[:metadata] || {}
           }
           self.data[:volumes][data['id']] = data
-          response.body = { 'volume' => data }
+          response.body = {'volume' => data}
           response
         end
       end

--- a/lib/fog/openstack/requests/compute/create_volume.rb
+++ b/lib/fog/openstack/requests/compute/create_volume.rb
@@ -1,8 +1,10 @@
+#
 module Fog
   module Compute
     class OpenStack
+      #
       class Real
-        def create_volume(name, description, size, options={})
+        def create_volume(name, description, size, options = {})
           data = {
             'volume' => {
               'display_name'        => name,
@@ -11,21 +13,28 @@ module Fog
             }
           }
 
-          vanilla_options = [:snapshot_id, :availability_zone]
-          vanilla_options.select{|o| options[o]}.each do |key|
+          vanilla_options = [
+            :snapshot_id,
+            :availability_zone,
+            :volume_type,
+            :metadata]
+
+          vanilla_options.select { |o| options[o] }.each do |key|
             data['volume'][key] = options[key]
           end
+
           request(
-            :body     => Fog::JSON.encode(data),
-            :expects  => [200, 202],
-            :method   => 'POST',
-            :path     => "os-volumes"
+            body: Fog::JSON.encode(data),
+            expects: [200, 202],
+            method: 'POST',
+            path: 'os-volumes'
           )
         end
       end
 
+      #
       class Mock
-        def create_volume(name, description, size, options={})
+        def create_volume(name, description, size, options = {})
           response = Excon::Response.new
           response.status = 202
           data = {
@@ -35,11 +44,11 @@ module Fog
             'size'                => size,
             'status'              => 'creating',
             'snapshotId'          => options[:snapshot_id],
-            'volumeType'          => 'None',
+            'volumeType'          => options[:volume_type] || 'None',
             'availabilityZone'    => options[:availability_zone] || 'nova',
             'createdAt'           => Time.now.strftime('%FT%T.%6N'),
             'attachments'         => [],
-            'metadata'            => {}
+            'metadata'            => options[:metadata] || {}
           }
           self.data[:volumes][data['id']] = data
           response.body = { 'volume' => data }


### PR DESCRIPTION
according to http://developer.openstack.org/api-ref-compute-v2.1.html   --> /v2.1/​{tenant_id}​/os-volumes
added `volume_type` and `metadata` in `compute/create_volume` option