### PR TITLE
Add query filter parameter to metering events

### DIFF
--- a/lib/fog/openstack/docs/metering.md
+++ b/lib/fog/openstack/docs/metering.md
@@ -20,8 +20,22 @@ service = Fog::Metering::OpenStack.new({
 
 ## Events
 
-* `service.events`: Return a list of events.
+* `service.events([<query_filter>])`: Return a list of events.
 * `service.events.find_by_id(<message_id>)`: Return the event matching message_id, or nil if no such event exists.
+
+### Filter events example
+
+Return events newer than 2016-03-17T09:59:44.606000.
+
+```ruby
+query_filter = [{
+  'field' => 'start_timestamp',
+  'op'    => 'gt',
+  'value' => '2016-03-17T09:59:44.606000'
+}]
+
+service.events(query_filter)
+```
 
 ## Resources
 

--- a/lib/fog/openstack/models/metering/events.rb
+++ b/lib/fog/openstack/models/metering/events.rb
@@ -7,8 +7,8 @@ module Fog
       class Events < Fog::OpenStack::Collection
         model Fog::Metering::OpenStack::Event
 
-        def all(detailed=true)
-          load_response(service.list_events)
+        def all(q=[])
+          load_response(service.list_events(q))
         end
 
         def find_by_id(message_id)


### PR DESCRIPTION
Example usage:
```ruby
query_filter = [{
  'field' => 'start_timestamp',
 'op'    => 'gt',
 'value' => '2016-03-17T09:59:44.606000'
}]
service.events(query_filter)
```