### PR TITLE
Fix logic to detect identity version

### DIFF
--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -3,25 +3,119 @@
 module Fog
   module Identity
     class OpenStack < Fog::Service
+      requires :openstack_auth_url
+      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
+                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
+                 :openstack_endpoint_type, :openstack_region, :openstack_domain_id,
+                 :openstack_project_name, :openstack_domain_name,
+                 :openstack_user_domain, :openstack_project_domain,
+                 :openstack_user_domain_id, :openstack_project_domain_id,
+                 :openstack_api_key, :openstack_current_user_id, :openstack_userid, :openstack_username,
+                 :current_user, :current_user_id, :current_tenant,
+                 :provider, :openstack_identity_prefix, :openstack_endpoint_path_matches
 
       # Fog::Identity::OpenStack.new() will return a Fog::Identity::OpenStack::V2 or a Fog::Identity::OpenStack::V3,
       #  depending on whether the auth URL is for an OpenStack Identity V2 or V3 API endpoint
       def self.new(args = {})
-        @openstack_auth_uri = URI.parse(args[:openstack_auth_url]) if args[:openstack_auth_url]
         if self.inspect == 'Fog::Identity::OpenStack'
-          service = (is_v3? args) ? Fog::Identity::OpenStack::V3.new(args) : Fog::Identity::OpenStack::V2.new(args)
+          identity = super
+          config = identity.config
+          service = identity.v3? ? Fog::Identity::OpenStack::V3.new(config) : Fog::Identity::OpenStack::V2.new(config)
         else
           service = Fog::Service.new(args)
         end
         service
       end
 
-      private
+      class Mock
+        attr_reader :config
 
-      def self.is_v3?(args)
-        @openstack_auth_uri && @openstack_auth_uri.path =~ /\/v3/
+        def initialize(options = {})
+          @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
+          @openstack_identity_prefix = options[:openstack_identity_prefix]
+          @config = options
+        end
+
+        def v3?
+          if @openstack_identity_prefix
+            @openstack_identity_prefix =~ /v3/
+          else
+            @openstack_auth_uri && @openstack_auth_uri.path =~ %r{/v3}
+          end
+        end
       end
 
+      class Real
+        DEFAULT_SERVICE_TYPE_V3 = %w(identity_v3 identityv3 identity).collect(&:freeze).freeze
+        DEFAULT_SERVICE_TYPE    = %w(identity).collect(&:freeze).freeze
+
+        def self.not_found_class
+          Fog::Identity::OpenStack::NotFound
+        end
+        include Fog::OpenStack::Common
+
+        def initialize(options = {})
+          if options.respond_to?(:config_service?) && options.config_service?
+            configure(options)
+            return
+          end
+
+          initialize_identity(options)
+
+          @openstack_service_type   = options[:openstack_service_type] || default_service_type(options)
+          @openstack_service_name   = options[:openstack_service_name]
+
+          @connection_options       = options[:connection_options] || {}
+
+          @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
+          initialize_endpoint_path_matches(options)
+
+          authenticate
+
+          if options[:openstack_identity_prefix]
+            @path = "/#{options[:openstack_identity_prefix]}/#{@path}"
+          end
+
+          @persistent = options[:persistent] || false
+          @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
+        end
+
+        def v3?
+          @path && @path =~ %r{/v3}
+        end
+
+        def config_service?
+          true
+        end
+
+        def config
+          self
+        end
+
+        private
+
+        def default_service_type(options)
+          unless options[:openstack_identity_prefix]
+            if @openstack_auth_uri.path =~ %r{/v3} ||
+               (options[:openstack_endpoint_path_matches] && options[:openstack_endpoint_path_matches] =~ '/v3')
+              return DEFAULT_SERVICE_TYPE_V3
+            end
+          end
+          DEFAULT_SERVICE_TYPE
+        end
+
+        def initialize_endpoint_path_matches(options)
+          if options[:openstack_endpoint_path_matches]
+            @openstack_endpoint_path_matches = options[:openstack_endpoint_path_matches]
+          end
+        end
+
+        def configure(source)
+          source.instance_variables.each do |v|
+            instance_variable_set(v, source.instance_variable_get(v))
+          end
+        end
+      end
     end
   end
 end

--- a/lib/fog/openstack/identity_v2.rb
+++ b/lib/fog/openstack/identity_v2.rb
@@ -171,30 +171,11 @@ module Fog
           end
         end
 
-        class Real
-          def self.not_found_class
-            Fog::Identity::OpenStack::NotFound
-          end
-          include Fog::OpenStack::Common
+        class Real < Fog::Identity::OpenStack::Real
+          private
 
-          def initialize(options={})
-            initialize_identity options
-
-            @openstack_service_type   = options[:openstack_service_type] || ['identity']
-            @openstack_service_name   = options[:openstack_service_name]
-
-            @connection_options       = options[:connection_options] || {}
-
-            @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
-
-            authenticate
-
-            if options[:openstack_identity_prefix]
-              @path = "/#{options[:openstack_identity_prefix]}/#{@path}"
-            end
-
-            @persistent = options[:persistent] || false
-            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
+          def default_service_type(_)
+            DEFAULT_SERVICE_TYPE
           end
         end
       end

--- a/lib/fog/openstack/identity_v3.rb
+++ b/lib/fog/openstack/identity_v3.rb
@@ -148,31 +148,19 @@ module Fog
           version
         end
 
-        class Real
-          def self.not_found_class
-            Fog::Identity::OpenStack::NotFound
+        class Real < Fog::Identity::OpenStack::Real
+          private
+
+          def default_service_type(_)
+            DEFAULT_SERVICE_TYPE_V3
           end
-          include Fog::OpenStack::Common
 
-          def initialize(options={})
-            initialize_identity options
-
-            @openstack_service_type   = options[:openstack_service_type] || ['identity_v3','identityv3','identity']
-            @openstack_service_name   = options[:openstack_service_name]
-
-            @connection_options       = options[:connection_options] || {}
-
-            @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
-
-            @openstack_endpoint_path_matches = options[:openstack_endpoint_path_matches] ||= /\/v3/
-            authenticate
-
-            if options[:openstack_identity_prefix]
-              @path = "/#{options[:openstack_identity_prefix]}/#{@path}"
+          def initialize_endpoint_path_matches(options)
+            if options[:openstack_endpoint_path_matches]
+              @openstack_endpoint_path_matches = options[:openstack_endpoint_path_matches]
+            else
+              @openstack_endpoint_path_matches = %r{/v3} unless options[:openstack_identity_prefix]
             end
-
-            @persistent = options[:persistent] || false
-            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
           end
         end
       end

--- a/tests/openstack/identity_version_tests.rb
+++ b/tests/openstack/identity_version_tests.rb
@@ -1,0 +1,25 @@
+Shindo.tests('Fog::Identity[:openstack] | versions', ['openstack', 'identity']) do
+  begin
+    @old_mock_value = Excon.defaults[:mock]
+    @old_credentials = Fog.credentials
+
+    tests('v2') do
+      Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v2.0/tokens'}
+
+      returns(Fog::Identity::OpenStack::V2::Mock) do
+        Fog::Identity[:openstack].class
+      end
+    end
+
+    tests('v3') do
+      Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v3/auth/tokens'}
+
+      returns(Fog::Identity::OpenStack::V3::Mock) do
+        Fog::Identity[:openstack].class
+      end
+    end
+  ensure
+    Excon.defaults[:mock] = @old_mock_value
+    Fog.credentials = @old_credentials
+  end
+end


### PR DESCRIPTION
Hello.

If we specify an identity v3 URL as `:openstack_auth_url` parameter in `~/.fog` file, `Fog::Identity::Openstack.new` method returns an instance of identity v2, not v3. It occurs because the configurations has not been read from the file, when `Fog::Identity::Openstack.new` method is invoked. So, `is_v3? args` in the method becomes `false` regardless of URL.

In this modification, identity version is detected after configurations are read from `~/.fog` file.