### PR TITLE
Fix Collection when body is empty

### DIFF
--- a/lib/fog/openstack/models/collection.rb
+++ b/lib/fog/openstack/models/collection.rb
@@ -11,7 +11,11 @@ module Fog
         # Delete it index if it's there, so we don't store response with data twice, but we store only metadata
         objects = index ? response.body.delete(index) : response.body
 
-        clear && objects.each { |object| self << new(object) }
+        if objects.empty?
+          clear
+        else
+          clear && objects.each { |object| self << new(object) }
+        end
         self.response = response
         self
       end


### PR DESCRIPTION
Adds a case to deal when the response body is empty.
For instance with rules_collection (with coming introspection models) a request
makes possible to delete all rules and it returns `body => ""`