### PR TITLE
changed path to use servers.json for block_device_mapping_v2

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -77,7 +77,7 @@ module Fog
             end
           end
 
-          path = block_device_mapping ? 'os-volumes_boot.json' : 'servers.json'
+          path = options['block_device_mapping'] ? 'os-volumes_boot.json' : 'servers.json'
 
           request(
             :body     => Fog::JSON.encode(data),


### PR DESCRIPTION
block_device_mapping_v2 comes under API POST /servers:
http://developer.openstack.org/api-ref-compute-v2.1.html#createServer

This was failing on our Icehouse based installation where the undocumented /os-volumes_boot API is not supported.