### PR TITLE
Adds services#get methods with some services tests

### DIFF
--- a/lib/fog/openstack/models/compute/services.rb
+++ b/lib/fog/openstack/models/compute/services.rb
@@ -17,6 +17,18 @@ module Fog
           Fog::Logger.deprecation('Calling OpenStack[:compute].services.details is deprecated, use .services.all')
           all(options)
         end
+
+        def get(service_id)
+          # OpenStack API currently does not support getting single service from it
+          # There is a blueprint https://blueprints.launchpad.net/nova/+spec/get-service-by-id
+          # with spec proposal patch https://review.openstack.org/#/c/172412/ but this is abandoned.
+          serv = service.list_services.body['services'].detect do |s|
+            s['id'] == service_id
+          end
+          new(serv) if serv
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
+        end
       end
     end
   end

--- a/tests/openstack/models/compute/service_tests.rb
+++ b/tests/openstack/models/compute/service_tests.rb
@@ -1,0 +1,17 @@
+Shindo.tests("Fog::Compute[:openstack] | services", ['openstack']) do
+  tests('success') do
+    tests('#all').succeeds do
+      services = Fog::Compute[:openstack].services.all
+      @service = services.first
+    end
+
+    tests('#get').succeeds do
+      service = Fog::Compute[:openstack].services.get(@service.id)
+      %w(id binary host).all? do |attr|
+        attr1 = service.send(attr.to_sym)
+        attr2 = @service.send(attr.to_sym)
+        attr1 == attr2
+      end
+    end
+  end
+end


### PR DESCRIPTION
OpenStack API currently does not support getting single service by its id.

This feature is wanted in https://github.com/ManageIQ/manageiq/pull/7996 so it seams better to have this ```find``` block here in fog-openstack with a chance to upgrade it to proper request when (and if) OpenStack API supports it.