### PR TITLE
A couple fixes for evacuate_server

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -302,7 +302,7 @@ module Fog
           service.live_migrate_server(id, host, block_migration, disk_over_commit)
         end
 
-        def evacuate(host, on_shared_storage, admin_password = nil)
+        def evacuate(host = nil, on_shared_storage = nil, admin_password = nil)
           requires :id
           service.evacuate_server(id, host, on_shared_storage, admin_password)
         end

--- a/lib/fog/openstack/requests/compute/evacuate_server.rb
+++ b/lib/fog/openstack/requests/compute/evacuate_server.rb
@@ -2,13 +2,13 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def evacuate_server(server_id, host, on_shared_storage, admin_password = nil)
+        def evacuate_server(server_id, host = nil, on_shared_storage = nil, admin_password = nil)
+          evacuate = {}
+          evacuate['host'] = host if host
+          evacuate['onSharedStorage'] = on_shared_storage if on_shared_storage
+          evacuate['adminPass'] = admin_password if admin_password
           body = {
-            'evacuate' => {
-              'host'            => host,
-              'onSharedStorage' => on_shared_storage,
-              'admin_password'  => admin_password,
-            }
+            'evacuate' => evacuate
           }
           server_action(server_id, body)
         end


### PR DESCRIPTION
1) don't pass in params with nil values
2) use adminPass instead of admin_password, as that's what the nova API expects