### PR TITLE
Fixing bug in prior evacuate fix for onSharedStorage

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -302,7 +302,7 @@ module Fog
           service.live_migrate_server(id, host, block_migration, disk_over_commit)
         end
 
-        def evacuate(host = nil, on_shared_storage = nil, admin_password = nil)
+        def evacuate(host = nil, on_shared_storage = true, admin_password = nil)
           requires :id
           service.evacuate_server(id, host, on_shared_storage, admin_password)
         end

--- a/lib/fog/openstack/requests/compute/evacuate_server.rb
+++ b/lib/fog/openstack/requests/compute/evacuate_server.rb
@@ -2,10 +2,9 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def evacuate_server(server_id, host = nil, on_shared_storage = nil, admin_password = nil)
-          evacuate = {}
+        def evacuate_server(server_id, host = nil, on_shared_storage = true, admin_password = nil)
+          evacuate = {'onSharedStorage' => on_shared_storage}
           evacuate['host'] = host if host
-          evacuate['onSharedStorage'] = on_shared_storage if on_shared_storage
           evacuate['adminPass'] = admin_password if admin_password
           body = {
             'evacuate' => evacuate


### PR DESCRIPTION
Further testing indicated a problem with the recent fixes to evacuate.
Contrary to the OpenStack CLI (where omitting --on-shared-storage is
a 'false' setting), the API treats this as a required param, needing
an explicit true or false.

This PR fixes that, defaulting the param to true