### PR TITLE
Remove fog-xml dependency

### DIFF
--- a/fog-openstack.gemspec
+++ b/fog-openstack.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fog-core',  '>= 1.38'
   spec.add_dependency 'fog-json',  '>= 1.0'
-  spec.add_dependency 'fog-xml',   '>= 0.1'
   spec.add_dependency 'ipaddress', '>= 0.8'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
This seems to be unused and pulls in nokogiri. Unit tests run smoothly without fog-xml. Getting rid of nokogiri is always a good thing, so here we go.

Please double-check in case the units don't cover essential functionality.

cc @dhague, @Ladas, @seanhandley, @mdarby, @jjasghar