### PR TITLE
Identity class creation refactor

### DIFF
--- a/spec/identity_v3_spec.rb
+++ b/spec/identity_v3_spec.rb
@@ -109,7 +109,6 @@ describe Fog::Identity::OpenStack::V3 do
   it 'get an unscoped token, then use it to get a scoped token' do
     VCR.use_cassette('authv3_unscoped') do
       skip 'get an unscoped token, then use it to get a scoped token to be fixed'
-=begin
       id_v3 = Fog::Identity::OpenStack::V3.new(
           :openstack_api_key => ENV['OS_PASSWORD'] || VCR_PASSWORD,
           :openstack_userid => ENV['OS_USER_ID']||VCR_USER_ID,
@@ -133,7 +132,6 @@ describe Fog::Identity::OpenStack::V3 do
 
       id_v3.tokens.check(token)
       proc { id_v3.tokens.check('random-token') }.must_raise Fog::Identity::OpenStack::NotFound
-=end
     end
   end
 

--- a/test/openstack/authenticate_tests.rb
+++ b/test/openstack/authenticate_tests.rb
@@ -103,13 +103,15 @@ describe "OpenStack authentication" do
   end
 
   it "validates token" do
-    openstack = Fog::Identity::OpenStack::V2.new
+    Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v2.0/tokens'}
+    openstack = Fog::Identity[:openstack]
     openstack.validate_token(@token, @tenant_token)
     openstack.validate_token(@token)
   end
 
   it "checks token" do
-    openstack = Fog::Identity::OpenStack::V2.new
+    Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v2.0/tokens'}
+    openstack = Fog::Identity[:openstack]
     openstack.check_token(@token, @tenant_token)
     openstack.check_token(@token)
   end

--- a/tests/openstack/models/identity/ec2_credential_tests.rb
+++ b/tests/openstack/models/identity/ec2_credential_tests.rb
@@ -1,6 +1,6 @@
 Shindo.tests("Fog::Identity[:openstack] | ec2_credential", ['openstack']) do
   before do
-    openstack = Fog::Identity[:openstack]
+    openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
     tenant_id = openstack.list_tenants.body['tenants'].first['id']
 
     @user = openstack.users.find { |user| user.name == 'foobar' }

--- a/tests/openstack/models/identity/ec2_credentials_tests.rb
+++ b/tests/openstack/models/identity/ec2_credentials_tests.rb
@@ -1,6 +1,6 @@
 Shindo.tests("Fog::Identity[:openstack] | ec2_credentials", ['openstack']) do
   before do
-    openstack = Fog::Identity[:openstack]
+    openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
     tenant_id = openstack.list_tenants.body['tenants'].first['id']
 
     @user = openstack.users.find { |user| user.name == 'foobar' }

--- a/tests/openstack/models/identity/role_tests.rb
+++ b/tests/openstack/models/identity/role_tests.rb
@@ -1,7 +1,12 @@
 Shindo.tests("Fog::Identity[:openstack] | role", ['openstack']) do
-  @instance = Fog::Identity[:openstack].roles.new({:name => 'Role Name', :user_id => 1, :role_id => 1})
-  @tenant   = Fog::Identity[:openstack].tenants.create(:name => 'test_user')
-  @user     = Fog::Identity[:openstack].users.create(:name => 'test_user', :tenant_id => @tenant.id, :password => 'spoof')
+  @identity = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+  @instance = @identity.roles.new(
+    :name    => 'Role Name',
+    :user_id => 1,
+    :role_id => 1
+  )
+  @tenant   = @identity.tenants.create(:name => 'test_user')
+  @user     = @identity.users.create(:name => 'test_user', :tenant_id => @tenant.id, :password => 'spoof')
 
   tests('success') do
     tests('#save').returns(true) do

--- a/tests/openstack/models/identity/roles_tests.rb
+++ b/tests/openstack/models/identity/roles_tests.rb
@@ -1,8 +1,9 @@
 Shindo.tests("Fog::Identity[:openstack] | roles", ['openstack']) do
-  @tenant   = Fog::Identity[:openstack].tenants.create(:name => 'test_user')
-  @user     = Fog::Identity[:openstack].users.create(:name => 'test_user', :tenant_id => @tenant.id, :password => 'spoof')
-  @role     = Fog::Identity[:openstack].roles(:user => @user, :tenant => @tenant).create(:name => 'test_role')
-  @roles    = Fog::Identity[:openstack].roles(:user => @user, :tenant => @tenant)
+  @identity = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+  @tenant   = @identity.tenants.create(:name => 'test_user')
+  @user     = @identity.users.create(:name => 'test_user', :tenant_id => @tenant.id, :password => 'spoof')
+  @role     = @identity.roles(:user => @user, :tenant => @tenant).create(:name => 'test_role')
+  @roles    = @identity.roles(:user => @user, :tenant => @tenant)
 
   tests('success') do
     tests('#all').succeeds do

--- a/tests/openstack/models/identity/tenant_tests.rb
+++ b/tests/openstack/models/identity/tenant_tests.rb
@@ -1,20 +1,23 @@
 Shindo.tests("Fog::Identity[:openstack] | tenant", ['openstack']) do
   tests('success') do
+    @openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+
     tests('#roles_for(0)').succeeds do
-      instance = Fog::Identity[:openstack].tenants.first
+      instance = @openstack.tenants.first
       instance.roles_for(0)
     end
 
     tests('#users').succeeds do
-      instance = Fog::Identity[:openstack].tenants.first
+      instance = @openstack.tenants.first
+      openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
 
-      instance.users.count != Fog::Identity[:openstack].users.count
+      instance.users.count != openstack.users.count
     end
   end
 
   tests('CRUD') do
     tests('#create').succeeds do
-      @instance = Fog::Identity[:openstack].tenants.create(:name => 'test')
+      @instance = @openstack.tenants.create(:name => 'test')
       !@instance.id.nil?
     end
 

--- a/tests/openstack/models/identity/tenants_tests.rb
+++ b/tests/openstack/models/identity/tenants_tests.rb
@@ -1,14 +1,17 @@
 Shindo.tests("Fog::Compute[:openstack] | tenants", ['openstack']) do
-  @instance = Fog::Identity[:openstack].tenants.create(:name => 'test')
+  openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+  @instance = openstack.tenants.create(:name => 'test')
 
   tests('success') do
     tests('#find_by_id').succeeds do
-      tenant = Fog::Identity[:openstack].tenants.find_by_id(@instance.id)
+      openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+      tenant = openstack.tenants.find_by_id(@instance.id)
       tenant.id == @instance.id
     end
 
     tests('#destroy').succeeds do
-      Fog::Identity[:openstack].tenants.destroy(@instance.id)
+      openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+      openstack.tenants.destroy(@instance.id)
     end
   end
 
@@ -16,11 +19,13 @@ Shindo.tests("Fog::Compute[:openstack] | tenants", ['openstack']) do
     pending if Fog.mocking?
 
     tests('#find_by_id').raises(Fog::Identity::OpenStack::NotFound) do
-      Fog::Identity[:openstack].tenants.find_by_id('fake')
+      openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+      openstack.tenants.find_by_id('fake')
     end
 
     tests('#destroy').raises(Fog::Identity::OpenStack::NotFound) do
-      Fog::Identity[:openstack].tenants.destroy('fake')
+      openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+      openstack.tenants.destroy('fake')
     end
   end
 end

--- a/tests/openstack/models/identity/user_tests.rb
+++ b/tests/openstack/models/identity/user_tests.rb
@@ -1,12 +1,13 @@
 Shindo.tests("Fog::Identity[:openstack] | user", ['openstack']) do
-  tenant_id = Fog::Identity[:openstack].list_tenants.body['tenants'].first['id']
-  @instance = Fog::Identity[:openstack].users.new({
+  openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+  tenant_id = openstack.list_tenants.body['tenants'].first['id']
+  @instance = openstack.users.new(
     :name      => 'User Name',
     :email     => 'test@fog.com',
     :tenant_id => tenant_id,
     :password  => 'spoof',
     :enabled   => true
-  })
+  )
 
   tests('success') do
     tests('#save').returns(true) do

--- a/tests/openstack/models/identity/users_tests.rb
+++ b/tests/openstack/models/identity/users_tests.rb
@@ -1,26 +1,30 @@
 Shindo.tests("Fog::Identity[:openstack] | users", ['openstack']) do
-  tenant_id = Fog::Identity[:openstack].list_tenants.body['tenants'].first['id']
-  @instance = Fog::Identity[:openstack].users.create({
+  openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+  tenant_id = openstack.list_tenants.body['tenants'].first['id']
+  @instance = openstack.users.create(
     :name      => 'foobar',
     :email     => 'foo@bar.com',
     :tenant_id => tenant_id,
     :password  => 'spoof',
     :enabled   => true
-  })
+  )
 
   tests('success') do
     tests('#find_by_id').succeeds do
-      user = Fog::Identity[:openstack].users.find_by_id(@instance.id)
+      openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+      user = openstack.users.find_by_id(@instance.id)
       user.id == @instance.id
     end
 
     tests('#find_by_name').succeeds do
-      user = Fog::Identity[:openstack].users.find_by_name(@instance.name)
+      openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+      user = openstack.users.find_by_name(@instance.name)
       user.name == @instance.name
     end
 
     tests('#destroy').succeeds do
-      Fog::Identity[:openstack].users.destroy(@instance.id)
+      openstack = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+      openstack.users.destroy(@instance.id)
     end
   end
 

--- a/tests/openstack/requests/identity/ec2_credentials_tests.rb
+++ b/tests/openstack/requests/identity/ec2_credentials_tests.rb
@@ -7,15 +7,15 @@ Shindo.tests('Fog::Identity[:openstack] | EC2 credential requests', ['openstack'
     'user_id'   => String,
   }
 
+  @identity = Fog::Identity::OpenStack.new(:openstack_auth_url => "http://openstack:35357/v2.0/tokens")
+
   @user_id = OpenStack::Identity.get_user_id
   @tenant_id = OpenStack::Identity.get_tenant_id
 
   tests('success') do
     tests('#create_ec2_credential').
       formats({'credential' => @credential_format}) do
-      response =
-        Fog::Identity[:openstack].
-          create_ec2_credential(@user_id, @tenant_id)
+      response = @identity.create_ec2_credential(@user_id, @tenant_id)
 
       @ec2_credential = response.body['credential']
 
@@ -24,19 +24,16 @@ Shindo.tests('Fog::Identity[:openstack] | EC2 credential requests', ['openstack'
 
     tests('#get_ec2_credential').
       formats({'credential' => @credential_format}) do
-      Fog::Identity[:openstack].
-        get_ec2_credential(@user_id, @ec2_credential['access']).body
+      @identity.get_ec2_credential(@user_id, @ec2_credential['access']).body
     end
 
     tests('#list_ec2_credentials').
       formats({'credentials' => [@credential_format]}) do
-      Fog::Identity[:openstack].
-        list_ec2_credentials(@user_id).body
+      @identity.list_ec2_credentials(@user_id).body
     end
 
     tests('#delete_ec2_credential').succeeds do
-      Fog::Identity[:openstack].
-        delete_ec2_credential(@user_id, @ec2_credential['access'])
+      @identity.delete_ec2_credential(@user_id, @ec2_credential['access'])
     end
 
   end

--- a/tests/openstack/requests/identity/helper.rb
+++ b/tests/openstack/requests/identity/helper.rb
@@ -1,13 +1,21 @@
 class OpenStack
   module Identity
-    def self.get_tenant_id
-      identity = Fog::Identity[:openstack]
+    def self.get_tenant_id_old
+      identity = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
       ENV['OPENSTACK_TENANT_NAME'] || identity.list_tenants.body['tenants'].first['id']
     end
 
-    def self.get_user_id
-      identity = Fog::Identity[:openstack]
+    def self.get_user_id_old
+      identity = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
       ENV['OPENSTACK_USER_ID'] || identity.list_users.body['users'].first['id']
+    end
+
+    def self.get_tenant_id
+      'tenant_id'
+    end
+
+    def self.get_user_id
+      'user_id'
     end
   end
 end

--- a/tests/openstack/requests/identity/role_tests.rb
+++ b/tests/openstack/requests/identity/role_tests.rb
@@ -3,42 +3,45 @@ Shindo.tests('Fog::Identity[:openstack] | role requests', ['openstack']) do
     'id'   => String,
     'name' => String
   }
-  @user   = Fog::Identity[:openstack].list_users.body['users'].first
-  @tenant = Fog::Identity[:openstack].list_tenants.body['tenants'].first
+
+  @identity = Fog::Identity::OpenStack.new(:openstack_auth_url => 'http://openstack:35357/v2.0/tokens')
+
+  @user   = @identity.list_users.body['users'].first
+  @tenant = @identity.list_tenants.body['tenants'].first
   tests('success') do
 
     tests('#create_role("Role Name")').formats(@role_format, false) do
-      @role = Fog::Identity[:openstack].create_role("Role Name").body['role']
+      @role = @identity.create_role("Role Name").body['role']
     end
 
     tests('#list_roles').formats({'roles' => [@role_format]}) do
-      Fog::Identity[:openstack].list_roles.body
+      @identity.list_roles.body
     end
 
     tests("#get_role('#{@role['id']}')").formats(@role_format) do
-      Fog::Identity[:openstack].get_role(@role['id']).body['role']
+      @identity.get_role(@role['id']).body['role']
     end
 
     tests('#create_user_role(@tenant["id"], @user["id"], @role["id"])').formats(@role_format) do
-      Fog::Identity[:openstack].create_user_role(@tenant['id'], @user['id'], @role['id']).body['role']
+      @identity.create_user_role(@tenant['id'], @user['id'], @role['id']).body['role']
     end
 
     tests("#list_roles_for_user_on_tenant('#{@tenant['id']}','#{@user['id']}')").formats([@role_format]) do
-      Fog::Identity[:openstack].list_roles_for_user_on_tenant(@tenant['id'], @user['id']).body['roles']
+      @identity.list_roles_for_user_on_tenant(@tenant['id'], @user['id']).body['roles']
     end
 
     tests("#delete_user_role with tenant").returns("") do
-      Fog::Identity[:openstack].delete_user_role(@tenant['id'], @user['id'], @role['id']).body
+      @identity.delete_user_role(@tenant['id'], @user['id'], @role['id']).body
     end
 
     tests("#delete_user_role with tenant").formats(@role_format) do
       # FIXME - Response (under mocks) is empty String which does not match schema
       pending
-      Fog::Identity[:openstack].delete_user_role(@tenant['id'], @user['id'], @role['id']).body
+      @identity.delete_user_role(@tenant['id'], @user['id'], @role['id']).body
     end
 
     tests("#delete_role('#{@role['id']}')").succeeds do
-      Fog::Identity[:openstack].delete_role(@role['id']).body
+      @identity.delete_role(@role['id']).body
     end
 
   end

--- a/tests/openstack/requests/identity/tenant_tests.rb
+++ b/tests/openstack/requests/identity/tenant_tests.rb
@@ -16,40 +16,41 @@ Shindo.tests('Fog::Identity[:openstack] | tenant requests', ['openstack']) do
   @tenant_name_update = Fog::Mock.random_hex(64)
   @tenant_name_update2 = Fog::Mock.random_hex(64)
 
+  @identity = Fog::Identity[:openstack]
+
   tests('success') do
     tests('#list_tenants').formats({'tenants' => [@tenant_format], 'tenants_links' => []}) do
-      Fog::Identity[:openstack].list_tenants.body
+      @identity.list_tenants.body
     end
 
     tests('#list_roles_for_user_on_tenant(0,1)').
       formats({'roles' => [@role_format]}) do
 
-      openstack = Fog::Identity[:openstack]
-      openstack.list_roles_for_user_on_tenant(
-        openstack.current_tenant['id'], OpenStack::Identity.get_user_id).body
+      @identity.list_roles_for_user_on_tenant(
+        @identity.current_tenant['id'], OpenStack::Identity.get_user_id).body
     end
 
     tests('#create_tenant').formats({'tenant' => @tenant_format}) do
-      @tenant = Fog::Identity[:openstack].create_tenant('name' => @tenant_name).body
+      @tenant = @identity.create_tenant('name' => @tenant_name).body
     end
 
     tests('#get_tenant').formats({'tenant' => @tenant_format}) do
-      Fog::Identity[:openstack].get_tenant(@tenant['tenant']['id']).body
+      @identity.get_tenant(@tenant['tenant']['id']).body
     end
 
     tests('#update_tenant check format').formats({'tenant' => @tenant_format}) do
-      @tenant = Fog::Identity[:openstack].update_tenant(
+      @tenant = @identity.update_tenant(
         @tenant['tenant']['id'], 'name' => @tenant_name_update).body
     end
 
     tests('#update_tenant update name').succeeds do
-      @tenant = Fog::Identity[:openstack].update_tenant(
+      @tenant = @identity.update_tenant(
         @tenant['tenant']['id'], 'name' => @tenant_name_update2).body
       @tenant['tenant']['name'] == @tenant_name_update2
     end
 
     tests('#delete_tenant').succeeds do
-      Fog::Identity[:openstack].delete_tenant(@tenant['tenant']['id'])
+      @identity.delete_tenant(@tenant['tenant']['id'])
     end
 
   end

--- a/tests/openstack/requests/identity/user_tests.rb
+++ b/tests/openstack/requests/identity/user_tests.rb
@@ -8,33 +8,38 @@ Shindo.tests('Fog::Identity[:openstack] | user requests', ['openstack']) do
     'tenantId' => Fog::Nullable::String
   }
 
+  @identity = Fog::Identity[:openstack]
+
   tests('success') do
 
     @user_name = Fog::Mock.random_hex(64)
     @user_name_update = Fog::Mock.random_hex(64)
 
     tests("#create_user('#{@user_name}', 'mypassword', 'morph@example.com', 't3n4nt1d', true)").formats(@user_format, false) do
-      @user = Fog::Identity[:openstack].create_user(@user_name, "mypassword", "morph@example.com", OpenStack::Identity.get_tenant_id).body['user']
+      @user = @identity.create_user(
+        @user_name, "mypassword", "morph@example.com",
+        OpenStack::Identity.get_tenant_id
+      ).body['user']
     end
 
     tests('#list_users').formats({'users' => [@user_format]}) do
-      Fog::Identity[:openstack].list_users.body
+      @identity.list_users.body
     end
 
     tests('#get_user_by_id').formats(@user_format) do
-      Fog::Identity[:openstack].get_user_by_id(@user['id']).body['user']
+      @identity.get_user_by_id(@user['id']).body['user']
     end
 
     tests('#get_user_by_name').formats(@user_format) do
-      Fog::Identity[:openstack].get_user_by_name(@user['name']).body['user']
+      @identity.get_user_by_name(@user['name']).body['user']
     end
 
     tests("#update_user(#{@user['id']}, :name => 'fogupdateduser')").succeeds do
-      Fog::Identity[:openstack].update_user(@user['id'], :name => @user_name_update, :email => 'fog@test.com')
+      @identity.update_user(@user['id'], :name => @user_name_update, :email => 'fog@test.com')
     end
 
     tests("#delete_user(#{@user['id']})").succeeds do
-      Fog::Identity[:openstack].delete_user(@user['id'])
+      @identity.delete_user(@user['id'])
     end
 
   end

--- a/tests/openstack/requests/image/image_tests.rb
+++ b/tests/openstack/requests/image/image_tests.rb
@@ -1,5 +1,6 @@
 Shindo.tests('Fog::Image[:openstack] | image requests', ['openstack']) do
   openstack = Fog::Identity[:openstack]
+
   @image_attributes = {
     :name             => 'new image',
     :owner            => openstack.current_tenant['id'],


### PR DESCRIPTION
This is step 1 towards identity v3 as the default version.
Effectively since Openstack Kilo, Keystone engine is by default version 3 while
still providing service to API v2.0.

This is one step closer to a configuration where the endpoints for v3 don't have
to be created along the default v2.0 which are not deprecated yet.