### PR TITLE
implement network rbac policies

### DIFF
--- a/lib/fog/openstack/models/network/rbac_policies.rb
+++ b/lib/fog/openstack/models/network/rbac_policies.rb
@@ -1,0 +1,33 @@
+require 'fog/openstack/models/collection'
+require 'fog/openstack/models/network/rbac_policy'
+
+module Fog
+  module Network
+    class OpenStack
+      class RbacPolicies < Fog::OpenStack::Collection
+        attribute :filters
+
+        model Fog::Network::OpenStack::RbacPolicy
+
+        def initialize(attributes)
+          self.filters ||= {}
+          super
+        end
+
+        def all(filters_arg = filters)
+          filters = filters_arg
+          load_response(service.list_rbac_policies(filters), 'rbac_policies')
+        end
+
+        def get(rbac_policy_id)
+          if rbac_policy = service.get_rbac_policy(rbac_policy_id).body['rbac_policy']
+            new(rbac_policy)
+          end
+        rescue Fog::Network::OpenStack::NotFound
+          nil
+        end
+        alias_method :find_by_id, :get
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/rbac_policy.rb
+++ b/lib/fog/openstack/models/network/rbac_policy.rb
@@ -1,0 +1,35 @@
+require 'fog/openstack/models/model'
+
+module Fog
+  module Network
+    class OpenStack
+      class RbacPolicy < Fog::OpenStack::Model
+        identity :id
+
+        attribute :object_type
+        attribute :object_id
+        attribute :tenant_id
+        attribute :target_tenant
+        attribute :action
+
+        def create
+          requires :object_type, :object_id, :target_tenant, :action
+          merge_attributes(service.create_rbac_policy(attributes).body['rbac_policy'])
+          self
+        end
+
+        def update
+          requires :id, :target_tenant
+          merge_attributes(service.update_rbac_policy(id, attributes).body['rbac_policy'])
+          self
+        end
+
+        def destroy
+          requires :id
+          service.delete_rbac_policy(id)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -46,6 +46,8 @@ module Fog
       collection  :ipsec_policies
       model       :ipsec_site_connection
       collection  :ipsec_site_connections
+      model       :rbac_policy
+      collection  :rbac_policies
       model       :security_group
       collection  :security_groups
       model       :security_group_rule
@@ -152,6 +154,13 @@ module Fog
       request :get_ipsec_site_connection
       request :update_ipsec_site_connection
 
+      # RBAC Policy CRUD
+      request :list_rbac_policies
+      request :create_rbac_policy
+      request :delete_rbac_policy
+      request :get_rbac_policy
+      request :update_rbac_policy
+
       # Security Group
       request :create_security_group
       request :delete_security_group
@@ -229,6 +238,7 @@ module Fog
               :ike_policies           => {},
               :ipsec_policies         => {},
               :ipsec_site_connections => {},
+              :rbac_policies          => {},
               :quota                  => {
                 "subnet"     => 10,
                 "router"     => 10,

--- a/lib/fog/openstack/requests/network/create_rbac_policy.rb
+++ b/lib/fog/openstack/requests/network/create_rbac_policy.rb
@@ -1,0 +1,42 @@
+module Fog
+  module Network
+    class OpenStack
+      class Real
+        def create_rbac_policy(options = {})
+          data = {'rbac_policy' => {}}
+
+          vanilla_options = [:object_type, :object_id, :tenant_id, :target_tenant, :action]
+          vanilla_options.select { |o| options.key?(o) }.each do |key|
+            data['rbac_policy'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => [201],
+            :method  => 'POST',
+            :path    => 'rbac-policies'
+          )
+        end
+      end
+
+      class Mock
+        def create_rbac_policy(options = {})
+          response = Excon::Response.new
+          response.status = 201
+          data = {
+            'id'            => Fog::Mock.random_numbers(6).to_s,
+            'object_type'   => options[:object_type],
+            'object_id'     => options[:object_id],
+            'tenant_id'     => options[:tenant_id],
+            'target_tenant' => options[:target_tenant],
+            'action'        => options[:action]
+          }
+
+          self.data[:rbac_policies][data['id']] = data
+          response.body = {'rbac_policy' => data}
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/delete_rbac_policy.rb
+++ b/lib/fog/openstack/requests/network/delete_rbac_policy.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Network
+    class OpenStack
+      class Real
+        def delete_rbac_policy(rbac_policy_id)
+          request(
+            :expects => 204,
+            :method  => 'DELETE',
+            :path    => "rbac-policies/#{rbac_policy_id}"
+          )
+        end
+      end
+
+      class Mock
+        def delete_rbac_policy(rbac_policy_id)
+          response = Excon::Response.new
+          if list_rbac_policies.body['rbac_policies'].collect { |r| r['id'] }.include? rbac_policy_id
+            data[:rbac_policies].delete(rbac_policy_id)
+            response.status = 204
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/get_rbac_policy.rb
+++ b/lib/fog/openstack/requests/network/get_rbac_policy.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Network
+    class OpenStack
+      class Real
+        def get_rbac_policy(rbac_policy_id)
+          request(
+            :expects => [200],
+            :method  => 'GET',
+            :path    => "rbac-policies/#{rbac_policy_id}"
+          )
+        end
+      end
+
+      class Mock
+        def get_rbac_policy(rbac_policy_id)
+          response = Excon::Response.new
+          if data = self.data[:rbac_policies][rbac_policy_id]
+            response.status = 200
+            response.body   = {'rbac_policy' => data}
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/list_rbac_policies.rb
+++ b/lib/fog/openstack/requests/network/list_rbac_policies.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Network
+    class OpenStack
+      class Real
+        def list_rbac_policies(filters = {})
+          request(
+            :expects => 200,
+            :method  => 'GET',
+            :path    => 'rbac-policies',
+            :query   => filters
+          )
+        end
+      end
+
+      class Mock
+        def list_rbac_policies(*)
+          Excon::Response.new(
+            :body   => {'rbac_policies' => data[:rbac_policies].values},
+            :status => 200
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/update_rbac_policy.rb
+++ b/lib/fog/openstack/requests/network/update_rbac_policy.rb
@@ -1,0 +1,41 @@
+module Fog
+  module Network
+    class OpenStack
+      class Real
+        def update_rbac_policy(rbac_policy_id, options = {})
+          data = {'rbac_policy' => {}}
+
+          vanilla_options = [:target_tenant]
+          vanilla_options.select { |o| options.key?(o) }.each do |key|
+            data['rbac_policy'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => 200,
+            :method  => 'PUT',
+            :path    => "rbac-policies/#{rbac_policy_id}"
+          )
+        end
+      end
+
+      class Mock
+        def update_rbac_policy(rbac_policy_id, options = {})
+          response = Excon::Response.new
+          rbac_policy = list_rbac_policies.body['rbac_policies'].detect do |instance|
+            instance['id'] == rbac_policy_id
+          end
+          if rbac_policy
+            rbac_policy['target_tenant'] = options[:target_tenant]
+
+            response.body = {'rbac_policy' => rbac_policy}
+            response.status = 200
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/openstack/network/common_setup.yml
+++ b/spec/fixtures/openstack/network/common_setup.yml
@@ -1,6 +1,38 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: http://devstack.openstack.stack:9696/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1cc71e8d89934d00a84d4ef13a048da3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '120'
+      Date:
+      - Wed, 11 May 2016 11:30:07 GMT
+    body:
+      encoding: UTF-8
+      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
+        "http://devstack.openstack.stack:9696/v2.0", "rel": "self"}]}]}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 11:30:12 GMT
+- request:
     method: post
     uri: http://devstack.openstack.stack:5000/v3/auth/tokens
     body:
@@ -17,118 +49,139 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Tue, 03 May 2016 13:38:18 GMT
+      - Wed, 11 May 2016 11:30:07 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       X-Subject-Token:
-      - 0afbf49d007a4d82850b853b703025d7
+      - 3b58d1663a9a49b2af240e68bfb08081
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9914c0c3-9af8-4ad4-96f1-d03e51ba4dc9
+      - req-61615d9a-8f2c-4642-9171-6e83b674fef8
       Content-Length:
-      - '4597'
+      - '2485'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
       string: '{"token": {"domain": {"id": "default", "name": "Default"}, "methods":
-        ["password"], "roles": [{"id": "5929fb4077c3415c9850e66f2c2be16b", "name":
-        "admin"}], "expires_at": "2016-05-03T14:38:18.465802Z", "catalog": [{"endpoints":
-        [], "type": "volumev2", "id": "1766683b2f9f4ef2acf7f9e4e359fb9a", "name":
-        "cinderv2"}, {"endpoints": [], "type": "metering", "id": "18dbb2f0ddeb45b99d11ed0568f153ab",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://mo-edbdf14f1.mo.sap.corp:8777/",
-        "region": "RegionOne", "interface": "admin", "id": "6f44eb5bf4e646f9a7afebb1f32501f1"},
-        {"region_id": "RegionOne", "url": "http://mo-edbdf14f1.mo.sap.corp:8777/",
-        "region": "RegionOne", "interface": "public", "id": "9bb4f1c83833484e9d53ce2b57d6308b"},
-        {"region_id": "RegionOne", "url": "http://mo-edbdf14f1.mo.sap.corp:8777/",
-        "region": "RegionOne", "interface": "internal", "id": "e62f1c8709554031ace717700c431635"}],
-        "type": "metering", "id": "261a2c1f467c4b148f38822ae9f179a3", "name": "ceilometer"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:35357/v3",
-        "region": "RegionOne", "interface": "admin", "id": "634d57ce5d534c808afb24127b7ac355"},
-        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
-        "RegionOne", "interface": "public", "id": "8a7a2620740c4c2fb6fabf15746c101f"},
-        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
-        "RegionOne", "interface": "internal", "id": "b53b60875b214e7f925f96d3a2a57464"}],
-        "type": "identity", "id": "311850187e5a47108ac9b43ec5346658", "name": "keystone"},
-        {"endpoints": [], "type": "compute", "id": "3fd114ff2cff43be8bd3ecc5bc117ec8",
-        "name": "nova"}, {"endpoints": [], "type": "volume", "id": "4a6033d57e30494a9577358d90d08123",
-        "name": "cinder"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8773/",
-        "region": "RegionOne", "interface": "internal", "id": "54546c7c383a4d6abc2b93c94d75e2f7"},
-        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8773/", "region": "RegionOne",
-        "interface": "admin", "id": "b253dd3d3f7d43d8ab35ad97c68440c3"}, {"region_id":
-        "RegionOne", "url": "http://devstack.openstack.stack:8773/", "region": "RegionOne", "interface":
-        "public", "id": "e7287110f01248d49cef8447d0f8d2cb"}], "type": "ec2", "id":
-        "5eff43878c134ae7a5f405cf0d191aff", "name": "ec2"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://i056593.dev.mo.sap.corp:8080/v2.0", "region":
-        "RegionOne", "interface": "internal", "id": "11d18be7930947f696db531c9bbdf245"},
-        {"region_id": "RegionOne", "url": "http://i056593.dev.mo.sap.corp:8080/v2.0",
-        "region": "RegionOne", "interface": "admin", "id": "a603e6ffd0804c4f82a8770d71dede64"},
-        {"region_id": "RegionOne", "url": "http://i056593.dev.mo.sap.corp:8080/v2.0",
-        "region": "RegionOne", "interface": "public", "id": "cf084db111ad4818a4f94080e0ed7819"}],
-        "type": "monitoring", "id": "73e3bfb0b1b944f0ace3a078baad1fcc", "name": "Monitoring"},
-        {"endpoints": [], "type": "compute_legacy", "id": "92e80becd6d8462b8f51fb227eb11999",
-        "name": "nova_legacy"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292",
-        "region": "RegionOne", "interface": "admin", "id": "acebdcb3418045b9a62ed295349327c3"},
-        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne",
-        "interface": "public", "id": "b3b24c2c4ef44ff48049caff79149091"}, {"region_id":
+        ["password"], "roles": [{"id": "289a88fea19045b0a042d0026ac5ee6d", "name":
+        "admin"}], "expires_at": "2016-05-11T12:30:07.699816Z", "catalog": [{"endpoints":
+        [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne",
+        "interface": "internal", "id": "10d69506a8f3408482090ef461813e6f"}, {"region_id":
         "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne", "interface":
-        "internal", "id": "b9d30173e66148baa3ab2dc2df33cb5e"}], "type": "image", "id":
-        "b936e5bfd38e4a3b97fcb8d08840881f", "name": "glance"}, {"endpoints": [{"region_id":
+        "public", "id": "9f04f53d3f7147db9d7524838496a9c9"}, {"region_id": "RegionOne",
+        "url": "http://devstack.openstack.stack:9292", "region": "RegionOne", "interface": "admin",
+        "id": "e5b2006675454d7bab41e6e307a3526b"}], "type": "image", "id": "07c0289b6ed24ab2ad9ab251d69bc360",
+        "name": "glance"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9696/",
+        "region": "RegionOne", "interface": "internal", "id": "63baac6b30244e39982163edb3eea7a1"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9696/", "region": "RegionOne",
+        "interface": "admin", "id": "7cbbd12dfc7d498a8e4be71b93e26ba4"}, {"region_id":
         "RegionOne", "url": "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface":
-        "admin", "id": "1a6718d75cd94e24993a27d275442a17"}, {"region_id": "RegionOne",
-        "url": "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface": "public",
-        "id": "5cfedecf28a54bd38031380dd0c255b1"}, {"region_id": "RegionOne", "url":
-        "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface": "internal",
-        "id": "e1be91e12d5646a8830c32146a3ed1aa"}], "type": "network", "id": "c626cfc79ed34e3699c2d96c58d105cd",
-        "name": "neutron"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8090",
-        "region": "RegionOne", "interface": "admin", "id": "b91bd1a6c34b4973b3d48f94516358bc"}],
-        "type": "object-store", "id": "e6a92b95728740ea9bda0c348a89f0f1", "name":
-        "swift"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "205e0e39a2534743b517ed0aa2fbcda7", "name": "admin"}, "audit_ids": ["8pdWd-ZfQraOmBCihYotGg"],
-        "issued_at": "2016-05-03T13:38:18.465852Z"}}'
+        "public", "id": "f1c9219c25d4474a8d8073274d210709"}], "type": "network", "id":
+        "3383f3f70d5844fa929196ac42f740ee", "name": "neutron"}, {"endpoints": [],
+        "type": "compute_legacy", "id": "43fc06691cf3403e9f52306dc155c44b", "name":
+        "nova_legacy"}, {"endpoints": [], "type": "compute", "id": "82a87e6c324c41228b2387d701b56572",
+        "name": "nova"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3",
+        "region": "RegionOne", "interface": "internal", "id": "2f46da49aa854fec81889bb74f53782a"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:35357/v3", "region":
+        "RegionOne", "interface": "admin", "id": "6c2384bcf3fb4460811caf75f06aacb9"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "public", "id": "e31e8a4680b047a6adc7eaeec5b2c2c8"}],
+        "type": "identity", "id": "d30ec3e1840b4e5abbc91d29341ba4cd", "name": "keystone"},
+        {"endpoints": [], "type": "volumev2", "id": "dd17c542cd954c4da3563375c61b6ab5",
+        "name": "cinderv2"}, {"endpoints": [], "type": "volume", "id": "e1d3a6c255fb4e3c8dfbba65e6f8a88d",
+        "name": "cinder"}], "user": {"domain": {"id": "default", "name": "Default"},
+        "id": "7a92283442cd4b8daf3cdd4ac1d8bb8a", "name": "admin"}, "audit_ids": ["83T_TlkHRw6JItqfK8ctyQ"],
+        "issued_at": "2016-05-11T11:30:07.699864Z"}}'
     http_version:
-  recorded_at: Tue, 03 May 2016 13:38:18 GMT
+  recorded_at: Wed, 11 May 2016 11:30:12 GMT
 - request:
-    method: get
-    uri: http://devstack.openstack.stack:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.32.1
-      Proxy-Connection:
-      - Keep-Alive
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3b58d1663a9a49b2af240e68bfb08081
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Thu, 29 Oct 2015 10:19:42 GMT
-      X-Cache:
-      - MISS from i056593-vagrant
-      X-Cache-Lookup:
-      - MISS from i056593-vagrant:3128
-      Via:
-      - 1.1 i056593-vagrant (squid/3.3.8)
-      Connection:
-      - keep-alive
+    method: post
+    uri: http://devstack.openstack.stack:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://devstack.openstack.stack:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Thu, 29 Oct 2015 10:19:37 GMT
-recorded_with: VCR 2.9.3
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password","domain":{"name":"Default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"name":"Default"}}}}}'
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Wed, 11 May 2016 12:13:57 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      X-Subject-Token:
+      - 3529b569335f4a43a40be0cfb0b4e635
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-3673b227-2e41-408c-8292-29ef86eb95b9
+      Content-Length:
+      - '4829'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "289a88fea19045b0a042d0026ac5ee6d",
+        "name": "admin"}], "is_admin_project": true, "project": {"domain": {"id":
+        "default", "name": "Default"}, "id": "dc4b3b173ee8467e9e2ae99e5c321d0c", "name":
+        "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292",
+        "region": "RegionOne", "interface": "internal", "id": "10d69506a8f3408482090ef461813e6f"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne",
+        "interface": "public", "id": "9f04f53d3f7147db9d7524838496a9c9"}, {"region_id":
+        "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne", "interface":
+        "admin", "id": "e5b2006675454d7bab41e6e307a3526b"}], "type": "image", "id":
+        "07c0289b6ed24ab2ad9ab251d69bc360", "name": "glance"}, {"endpoints": [{"region_id":
+        "RegionOne", "url": "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface":
+        "internal", "id": "63baac6b30244e39982163edb3eea7a1"}, {"region_id": "RegionOne",
+        "url": "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface": "admin",
+        "id": "7cbbd12dfc7d498a8e4be71b93e26ba4"}, {"region_id": "RegionOne", "url":
+        "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface": "public",
+        "id": "f1c9219c25d4474a8d8073274d210709"}], "type": "network", "id": "3383f3f70d5844fa929196ac42f740ee",
+        "name": "neutron"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8774/v2/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "public", "id": "397dc06293fb4e5fb683ea8c23dc27f4"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8774/v2/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "internal", "id": "95a1e8de18b342ce9f964ee129a5fd69"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8774/v2/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "admin", "id": "d38553afcb5446d3a38b5d95c74a6b3c"}],
+        "type": "compute_legacy", "id": "43fc06691cf3403e9f52306dc155c44b", "name":
+        "nova_legacy"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8774/v2.1/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "admin", "id": "ca081b14727d4f089c4801869e71dad8"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8774/v2.1/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "internal", "id": "d3b1545f1ce44723be67966d0b853c41"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8774/v2.1/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "public", "id": "fa1f5b65b32c4fb38cca2ce9e1fe09e3"}],
+        "type": "compute", "id": "82a87e6c324c41228b2387d701b56572", "name": "nova"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3",
+        "region": "RegionOne", "interface": "internal", "id": "2f46da49aa854fec81889bb74f53782a"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:35357/v3", "region":
+        "RegionOne", "interface": "admin", "id": "6c2384bcf3fb4460811caf75f06aacb9"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "public", "id": "e31e8a4680b047a6adc7eaeec5b2c2c8"}],
+        "type": "identity", "id": "d30ec3e1840b4e5abbc91d29341ba4cd", "name": "keystone"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8776/v2/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "internal", "id": "58630521c8214617a1805232d6427131"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8776/v2/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "public", "id": "6dce34d56bc6436cafff58c81ca76372"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8776/v2/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "admin", "id": "8753db765b534d11a7055a21ca1d04ef"}],
+        "type": "volumev2", "id": "dd17c542cd954c4da3563375c61b6ab5", "name": "cinderv2"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8776/v1/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "internal", "id": "27137a813d404515a52155b615295665"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8776/v1/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "public", "id": "4dbfad6771ca43b9b6152f52b9166d03"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8776/v1/dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "region": "RegionOne", "interface": "admin", "id": "692a7d6ac84947868c22f92ca0cd7f58"}],
+        "type": "volume", "id": "e1d3a6c255fb4e3c8dfbba65e6f8a88d", "name": "cinder"}],
+        "expires_at": "2016-05-11T13:13:57.865630Z", "user": {"domain": {"id": "default",
+        "name": "Default"}, "id": "7a92283442cd4b8daf3cdd4ac1d8bb8a", "name": "admin"},
+        "audit_ids": ["GCbB45jPStquTFlmUDH3Zg"], "issued_at": "2016-05-11T12:13:57.865659Z"}}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:14:02 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/openstack/network/rbacs_crud.yml
+++ b/spec/fixtures/openstack/network/rbacs_crud.yml
@@ -1,0 +1,510 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 3529b569335f4a43a40be0cfb0b4e635
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-03b8aa7b-9e49-4af8-98a8-0f68d9ee0c61
+      Content-Length:
+      - '1458'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects", "previous":
+        null, "next": null}, "projects": [{"is_domain": false, "description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/6df7cf36158a47e8a7736fd0c7693b06"},
+        "enabled": true, "id": "6df7cf36158a47e8a7736fd0c7693b06", "parent_id": "default",
+        "domain_id": "default", "name": "alt_demo"}, {"is_domain": false, "description":
+        "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/d1e053cab7a649c78c81739a189e1fd0"},
+        "enabled": true, "id": "d1e053cab7a649c78c81739a189e1fd0", "parent_id": "default",
+        "domain_id": "default", "name": "invisible_to_admin"}, {"is_domain": false,
+        "description": "Bootstrap project for initializing the cloud.", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/dc4b3b173ee8467e9e2ae99e5c321d0c"},
+        "enabled": true, "id": "dc4b3b173ee8467e9e2ae99e5c321d0c", "parent_id": "default",
+        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
+        "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/e02755e20b3942e9b68ead0c0d5fa291"},
+        "enabled": true, "id": "e02755e20b3942e9b68ead0c0d5fa291", "parent_id": "default",
+        "domain_id": "default", "name": "demo"}, {"is_domain": false, "description":
+        "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/fec49ae8596c465ab05895afaed75ff1"},
+        "enabled": true, "id": "fec49ae8596c465ab05895afaed75ff1", "parent_id": "default",
+        "domain_id": "default", "name": "service"}]}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:22 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 3529b569335f4a43a40be0cfb0b4e635
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-cf6b8ef7-a398-41a0-ae2e-437497bfbecd
+      Content-Length:
+      - '1458'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects", "previous":
+        null, "next": null}, "projects": [{"is_domain": false, "description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/6df7cf36158a47e8a7736fd0c7693b06"},
+        "enabled": true, "id": "6df7cf36158a47e8a7736fd0c7693b06", "parent_id": "default",
+        "domain_id": "default", "name": "alt_demo"}, {"is_domain": false, "description":
+        "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/d1e053cab7a649c78c81739a189e1fd0"},
+        "enabled": true, "id": "d1e053cab7a649c78c81739a189e1fd0", "parent_id": "default",
+        "domain_id": "default", "name": "invisible_to_admin"}, {"is_domain": false,
+        "description": "Bootstrap project for initializing the cloud.", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/dc4b3b173ee8467e9e2ae99e5c321d0c"},
+        "enabled": true, "id": "dc4b3b173ee8467e9e2ae99e5c321d0c", "parent_id": "default",
+        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
+        "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/e02755e20b3942e9b68ead0c0d5fa291"},
+        "enabled": true, "id": "e02755e20b3942e9b68ead0c0d5fa291", "parent_id": "default",
+        "domain_id": "default", "name": "demo"}, {"is_domain": false, "description":
+        "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/fec49ae8596c465ab05895afaed75ff1"},
+        "enabled": true, "id": "fec49ae8596c465ab05895afaed75ff1", "parent_id": "default",
+        "domain_id": "default", "name": "service"}]}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:22 GMT
+- request:
+    method: post
+    uri: http://devstack.openstack.stack:9696/v2.0/networks
+    body:
+      encoding: UTF-8
+      string: '{"network":{"name":"foo-net23","tenant_id":"dc4b3b173ee8467e9e2ae99e5c321d0c"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '596'
+      X-Openstack-Request-Id:
+      - req-dc14a78d-ede6-4249-a0ed-67833d84a778
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"network": {"status": "ACTIVE", "router:external": false, "availability_zone_hints":
+        [], "availability_zones": [], "description": "", "provider:physical_network":
+        null, "subnets": [], "shared": false, "name": "foo-net23", "created_at": "2016-05-11T12:05:18",
+        "tags": [], "updated_at": "2016-05-11T12:05:18", "provider:network_type":
+        "vxlan", "ipv6_address_scope": null, "tenant_id": "dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "admin_state_up": true, "ipv4_address_scope": null, "port_security_enabled":
+        true, "mtu": 1450, "id": "9bd99e12-499e-4f66-80c8-3239d03849bc", "provider:segmentation_id":
+        1087}}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:22 GMT
+- request:
+    method: post
+    uri: http://devstack.openstack.stack:9696/v2.0/rbac-policies
+    body:
+      encoding: UTF-8
+      string: '{"rbac_policy":{"object_type":"network","object_id":"9bd99e12-499e-4f66-80c8-3239d03849bc","tenant_id":"dc4b3b173ee8467e9e2ae99e5c321d0c","target_tenant":"6df7cf36158a47e8a7736fd0c7693b06","action":"access_as_shared"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '274'
+      X-Openstack-Request-Id:
+      - req-2b133cf6-a8d0-4584-8eeb-519ae364c2f6
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"rbac_policy": {"target_tenant": "6df7cf36158a47e8a7736fd0c7693b06",
+        "tenant_id": "dc4b3b173ee8467e9e2ae99e5c321d0c", "object_type": "network",
+        "object_id": "9bd99e12-499e-4f66-80c8-3239d03849bc", "action": "access_as_shared",
+        "id": "bc8255ca-0511-469f-87de-042bff269896"}}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:23 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:9696/v2.0/networks/9bd99e12-499e-4f66-80c8-3239d03849bc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '596'
+      X-Openstack-Request-Id:
+      - req-ec1a5f90-34b7-47e0-89ae-7086eee4d021
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"network": {"status": "ACTIVE", "router:external": false, "availability_zone_hints":
+        [], "availability_zones": [], "description": "", "provider:physical_network":
+        null, "subnets": [], "shared": false, "name": "foo-net23", "created_at": "2016-05-11T12:05:18",
+        "tags": [], "ipv6_address_scope": null, "provider:network_type": "vxlan",
+        "updated_at": "2016-05-11T12:05:18", "tenant_id": "dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "admin_state_up": true, "ipv4_address_scope": null, "port_security_enabled":
+        true, "mtu": 1450, "id": "9bd99e12-499e-4f66-80c8-3239d03849bc", "provider:segmentation_id":
+        1087}}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:23 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:9696/v2.0/rbac-policies?object_id=9bd99e12-499e-4f66-80c8-3239d03849bc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '278'
+      X-Openstack-Request-Id:
+      - req-5fad5792-88f3-4331-9221-a409535966dc
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"rbac_policies": [{"target_tenant": "6df7cf36158a47e8a7736fd0c7693b06",
+        "tenant_id": "dc4b3b173ee8467e9e2ae99e5c321d0c", "object_type": "network",
+        "object_id": "9bd99e12-499e-4f66-80c8-3239d03849bc", "action": "access_as_shared",
+        "id": "bc8255ca-0511-469f-87de-042bff269896"}]}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:23 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:9696/v2.0/rbac-policies/bc8255ca-0511-469f-87de-042bff269896
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '274'
+      X-Openstack-Request-Id:
+      - req-24cae1c8-405b-41fa-9141-9f8692c8f12f
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"rbac_policy": {"target_tenant": "6df7cf36158a47e8a7736fd0c7693b06",
+        "tenant_id": "dc4b3b173ee8467e9e2ae99e5c321d0c", "object_type": "network",
+        "object_id": "9bd99e12-499e-4f66-80c8-3239d03849bc", "action": "access_as_shared",
+        "id": "bc8255ca-0511-469f-87de-042bff269896"}}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:23 GMT
+- request:
+    method: put
+    uri: http://devstack.openstack.stack:9696/v2.0/rbac-policies/bc8255ca-0511-469f-87de-042bff269896
+    body:
+      encoding: UTF-8
+      string: '{"rbac_policy":{"target_tenant":"dc4b3b173ee8467e9e2ae99e5c321d0c"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '274'
+      X-Openstack-Request-Id:
+      - req-f1608536-bba5-45a4-aea9-164245193f0d
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"rbac_policy": {"target_tenant": "dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "tenant_id": "dc4b3b173ee8467e9e2ae99e5c321d0c", "object_type": "network",
+        "object_id": "9bd99e12-499e-4f66-80c8-3239d03849bc", "action": "access_as_shared",
+        "id": "bc8255ca-0511-469f-87de-042bff269896"}}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:23 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:9696/v2.0/networks/9bd99e12-499e-4f66-80c8-3239d03849bc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '595'
+      X-Openstack-Request-Id:
+      - req-a07f5d53-e868-45ef-987f-0c0a74c2dcfe
+      Date:
+      - Wed, 11 May 2016 12:05:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"network": {"status": "ACTIVE", "router:external": false, "availability_zone_hints":
+        [], "availability_zones": [], "description": "", "provider:physical_network":
+        null, "subnets": [], "shared": true, "name": "foo-net23", "created_at": "2016-05-11T12:05:18",
+        "tags": [], "ipv6_address_scope": null, "provider:network_type": "vxlan",
+        "updated_at": "2016-05-11T12:05:18", "tenant_id": "dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "admin_state_up": true, "ipv4_address_scope": null, "port_security_enabled":
+        true, "mtu": 1450, "id": "9bd99e12-499e-4f66-80c8-3239d03849bc", "provider:segmentation_id":
+        1087}}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:23 GMT
+- request:
+    method: delete
+    uri: http://devstack.openstack.stack:9696/v2.0/rbac-policies/bc8255ca-0511-469f-87de-042bff269896
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Content-Length:
+      - '0'
+      X-Openstack-Request-Id:
+      - req-9122b8d8-679e-403b-b4b1-9b4fdbbfc4c8
+      Date:
+      - Wed, 11 May 2016 12:05:19 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:23 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:9696/v2.0/rbac-policies?object_id=9bd99e12-499e-4f66-80c8-3239d03849bc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '21'
+      X-Openstack-Request-Id:
+      - req-ac391f88-06c2-4634-9e5f-5a95a0c16fbd
+      Date:
+      - Wed, 11 May 2016 12:05:19 GMT
+    body:
+      encoding: UTF-8
+      string: '{"rbac_policies": []}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:23 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:9696/v2.0/networks/9bd99e12-499e-4f66-80c8-3239d03849bc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '596'
+      X-Openstack-Request-Id:
+      - req-b583a998-3aca-4b72-a074-02500e3a011c
+      Date:
+      - Wed, 11 May 2016 12:05:19 GMT
+    body:
+      encoding: UTF-8
+      string: '{"network": {"status": "ACTIVE", "router:external": false, "availability_zone_hints":
+        [], "availability_zones": [], "description": "", "provider:physical_network":
+        null, "subnets": [], "shared": false, "name": "foo-net23", "created_at": "2016-05-11T12:05:18",
+        "tags": [], "ipv6_address_scope": null, "provider:network_type": "vxlan",
+        "updated_at": "2016-05-11T12:05:18", "tenant_id": "dc4b3b173ee8467e9e2ae99e5c321d0c",
+        "admin_state_up": true, "ipv4_address_scope": null, "port_security_enabled":
+        true, "mtu": 1450, "id": "9bd99e12-499e-4f66-80c8-3239d03849bc", "provider:segmentation_id":
+        1087}}'
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:24 GMT
+- request:
+    method: delete
+    uri: http://devstack.openstack.stack:9696/v2.0/networks/9bd99e12-499e-4f66-80c8-3239d03849bc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2488d4b6fc95451192247b282c89937c
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Content-Length:
+      - '0'
+      X-Openstack-Request-Id:
+      - req-0c68b400-4531-4523-8ac0-4f1c1c4fd67d
+      Date:
+      - Wed, 11 May 2016 12:05:19 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version:
+  recorded_at: Wed, 11 May 2016 12:05:24 GMT
+recorded_with: VCR 3.0.1

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -4,10 +4,18 @@ require_relative './shared_context'
 describe Fog::Network::OpenStack do
   before :all do
     openstack_vcr = OpenStackVCR.new(
-      :vcr_directory => 'spec/fixtures/openstack/network',
-      :service_class => Fog::Network::OpenStack,
+      :vcr_directory  => 'spec/fixtures/openstack/network',
+      :service_class  => Fog::Network::OpenStack,
+      :project_scoped => true
     )
-    @service = openstack_vcr.service
+    @service          = openstack_vcr.service
+    @current_project  = openstack_vcr.project_name
+
+    openstack_vcr = OpenStackVCR.new(
+      :vcr_directory => 'spec/fixtures/openstack/network',
+      :service_class => Fog::Identity::OpenStack::V3
+    )
+    @identity_service = openstack_vcr.service
   end
 
   it 'CRUD subnets' do
@@ -24,6 +32,45 @@ describe Fog::Network::OpenStack do
         subnet.name.must_equal 'my-network'
       ensure
         subnet.destroy if subnet
+        foonet.destroy if foonet
+      end
+    end
+  end
+
+  it 'CRUD rbacs' do
+    VCR.use_cassette('rbacs_crud') do
+      begin
+        own_project   = @identity_service.projects.select { |p| p.name == @current_project }.first
+        other_project = @identity_service.projects.select { |p| p.name != @current_project }.first
+
+        foonet = @service.networks.create(:name => 'foo-net23', :tenant_id => own_project.id)
+        # create share access for other project
+        rbac = @service.rbac_policies.create(
+          :object_type   => 'network',
+          :object_id     => foonet.id,
+          :tenant_id     => own_project.id,
+          :target_tenant => other_project.id,
+          :action        => 'access_as_shared'
+        )
+        rbac.target_tenant.must_equal other_project.id
+        foonet.reload.shared.must_equal false
+        @service.rbac_policies.all(:object_id => foonet.id).length.must_equal 1
+
+        # get
+        @service.rbac_policies.find_by_id(rbac.id).wont_equal nil
+
+        # change share target to own project
+        rbac.target_tenant = own_project.id
+        rbac.save
+        foonet.reload.shared.must_equal true
+
+        # delete the sharing
+        rbac.destroy
+        rbac = nil
+        @service.rbac_policies.all(:object_id => foonet.id).length.must_equal 0
+        foonet.reload.shared.must_equal false
+      ensure
+        rbac.destroy if rbac
         foonet.destroy if foonet
       end
     end


### PR DESCRIPTION
To access identity service for projects in network spec some adjustments to the shared_context was needed. And env `USE_VCR=true` now also works together with the `OS_` env present.

@dhague : FYI