### PR TITLE
Add list of supported projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is the plugin Gem to talk to [OpenStack](http://openstack.org) clouds via f
 
 The main maintainers for the OpenStack sections are @dhague, @Ladas, @seanhandley, @mdarby and @jjasghar. Please send CC them on pull requests.
 
+## Supported OpenStack APIs
+
+See the list of [supported OpenStack projects](supported.md).
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/supported.md
+++ b/supported.md
@@ -1,0 +1,54 @@
+# Supported OpenStack Projects
+
+## Supported
+
+| Project          | Fog Type      | API Version(s) | Compliance | Notes |
+|------------------|---------------|----------------|------------|-------|
+| Ceilometer       | Metering      | v2             | TBD        |       |
+| Cinder           | Volume        | v1, v2         | TBD        |       |
+| Glance           | Image         | v1, v2         | TBD        |       |
+| Heat             | Orchestration | v1             | TBD        |       |
+| Keystone         | Identity      | v2, v3         | TBD        |       |
+| Neutron          | Network       | v2             | TBD        |       |
+| Nova             | Compute       | v2.0           | TBD        |       |
+| Ironic           | Bare Metal    | v1             | TBD        |       |
+| Ironic Inspector | Introspection | v1             | TBD        |       |
+| Swift            | Storage       | v2             | TBD        |       |
+| Tacker           | NFV           | v1             | TBD        |       |
+
+## Wish List
+
+Feel free to submit pull requests to add support for these.
+
+* [barbican](https://wiki.openstack.org/wiki/Barbican) (Key Management)
+* [congress](https://wiki.openstack.org/wiki/Congress) (Policy As a Service)
+* [designate](https://wiki.openstack.org/wiki/Designate) (DNSaaS)
+* [magnum](https://wiki.openstack.org/wiki/Magnum) (Containers)
+* [manila](https://wiki.openstack.org/wiki/Manila) (File Storage)
+* [monasca](https://wiki.openstack.org/wiki/Monasca) (Monitoring)
+* [trove](https://wiki.openstack.org/wiki/Trove) (DBaaS)
+
+## Unsupported
+
+* aodh (Telemetry Alarms)
+* astara (Network)
+* cloudkitty (Telemetry)
+* cue (Messaging)
+* dragonflow (Network)
+* ec2-api (Compatibility Layer)
+* freezer (Disaster Recovery)
+* fuel (Orchestration)
+* gnocchi (TSDB)
+* horizon (Web Frontend)
+* kolla (Containers)
+* kuryr (Containers)
+* mistral (Workflow)
+* murano (Catalog Service)
+* rally (Benchmarking)
+* sahara (Map-Reduce)
+* searchlight (Searching)
+* senlin (Clustering)
+* solum (Lifecycle)
+* tripleo (Orchestration)
+* zaqar (Messaging)
+


### PR DESCRIPTION
We need a clear description of which OpenStack projects we support, which versions of the API, our level of compliance (completeness and correctness) and any additional information about the integration itself.

This will eventually be tied in with official OpenStack API compliance tests, details of which are TBD.