### PR TITLE
Shindo to Minitest - Common part 2

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,9 @@
 require 'minitest/autorun'
 require "minitest/spec"
 require 'fog/core'
+require 'fog/test_helpers/types_helper.rb'
+require 'fog/test_helpers/minitest/assertions'
+require 'fog/test_helpers/minitest/expectations'
 
 require File.expand_path('../../lib/fog/openstack', __FILE__)
 


### PR DESCRIPTION
Adds `require` stanza in `test/test_helper.rb` to be able to use
match_schema assertion/expectation