### PR TITLE
Shindo to Minitest - Common part 3

### DIFF
--- a/test/authenticate_tests.rb
+++ b/test/authenticate_tests.rb
@@ -103,17 +103,21 @@ describe "OpenStack authentication" do
   end
 
   it "validates token" do
+    old_credentials = Fog.credentials
     Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v2.0/tokens'}
-    openstack = Fog::Identity[:openstack]
-    openstack.validate_token(@token, @tenant_token)
-    openstack.validate_token(@token)
+    identity = Fog::Identity[:openstack]
+    identity.validate_token(@token, @tenant_token)
+    identity.validate_token(@token)
+    Fog.credentials = old_credentials
   end
 
   it "checks token" do
+    old_credentials = Fog.credentials
     Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v2.0/tokens'}
-    openstack = Fog::Identity[:openstack]
-    openstack.check_token(@token, @tenant_token)
-    openstack.check_token(@token)
+    identity = Fog::Identity[:openstack]
+    identity.check_token(@token, @tenant_token)
+    identity.check_token(@token)
+    Fog.credentials = old_credentials
   end
 
   it "v2 missing service" do
@@ -122,11 +126,13 @@ describe "OpenStack authentication" do
       {:status => 200, :body => Fog::JSON.encode(@body)}
     )
 
-    proc { Fog::OpenStack.authenticate_v2(
-      :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
-      :openstack_tenant       => 'admin',
-      :openstack_service_type => %w[network])
-    }.must_raise Fog::Errors::NotFound, 'Could not find service network.  Have compute, image'
+    proc do
+      Fog::OpenStack.authenticate_v2(
+        :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
+        :openstack_tenant       => 'admin',
+        :openstack_service_type => %w[network]
+      )
+    end.must_raise Fog::Errors::NotFound, 'Could not find service network.  Have compute, image'
   end
 
   it "v2 missing storage service" do
@@ -135,17 +141,21 @@ describe "OpenStack authentication" do
       {:status => 200, :body => Fog::JSON.encode(@body)}
     )
 
-    proc { Fog::OpenStack.authenticate_v2(
-      :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
-      :openstack_tenant       => 'admin',
-      :openstack_service_type => 'object-store')
-    }.must_raise NoMethodError, "undefined method `join' for \"object-store\":String"
+    proc do
+      Fog::OpenStack.authenticate_v2(
+        :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
+        :openstack_tenant       => 'admin',
+        :openstack_service_type => 'object-store'
+      )
+    end.must_raise NoMethodError, "undefined method `join' for \"object-store\":String"
 
-    proc { Fog::OpenStack.authenticate_v2(
-      :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
-      :openstack_tenant       => 'admin',
-      :openstack_service_type => %w[object-store])
-    }.must_raise Fog::Errors::NotFound, "Could not find service object-store.  Have compute, image"
+    proc do
+      Fog::OpenStack.authenticate_v2(
+        :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
+        :openstack_tenant       => 'admin',
+        :openstack_service_type => %w[object-store]
+      )
+    end.must_raise Fog::Errors::NotFound, "Could not find service object-store.  Have compute, image"
   end
 
   it "v2 auth with two compute services" do

--- a/test/identity_version_tests.rb
+++ b/test/identity_version_tests.rb
@@ -1,26 +1,28 @@
 require 'test_helper'
 
-describe "'Fog::Identity[:openstack] | versions', ['openstack', 'identity']" do
-  begin
+describe "Fog::Identity[:openstack] | versions" do
+  before do
     @old_mock_value = Excon.defaults[:mock]
     @old_credentials = Fog.credentials
+  end
 
-    it 'v2' do
-      Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v2.0/tokens'}
+  it "v2" do
+    Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v2.0/tokens'}
 
-      assert(Fog::Identity::OpenStack::V2::Mock) do
-        Fog::Identity[:openstack].class
-      end
+    assert(Fog::Identity::OpenStack::V2::Mock) do
+      Fog::Identity[:openstack].class
     end
+  end
 
-    it 'v3' do
-      Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v3/auth/tokens'}
+  it "v3" do
+    Fog.credentials = {:openstack_auth_url => 'http://openstack:35357/v3/auth/tokens'}
 
-      assert(Fog::Identity::OpenStack::V3::Mock) do
-        Fog::Identity[:openstack].class
-      end
+    assert(Fog::Identity::OpenStack::V3::Mock) do
+      Fog::Identity[:openstack].class
     end
-  ensure
+  end
+
+  after do
     Excon.defaults[:mock] = @old_mock_value
     Fog.credentials = @old_credentials
   end


### PR DESCRIPTION
Fix test identity leaks causing random errors
    
When Fog.credentials is altered by a test (or before) it must be restored at the end (or after) of the test.
    
This fixes authenticate_tests.rb and identity_version_tests.rb accordingly. It now avoids side effects cause some of the random test during testing.
