### PR TITLE
Compute create_server issue with volume

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -147,9 +147,9 @@ module Fog
           end
 
           if block_devices = options["block_device_mapping_v2"]
-            block_devices.each { |bd| compute.volumes.get(bd[:uuid]).attach(server_id, bd[:device_name]) }
+            block_devices.each { |bd| volumes.get(bd[:uuid]).attach(server_id, bd[:device_name]) }
           elsif block_device = options["block_device_mapping"]
-            compute.volumes.get(block_device[:volume_id]).attach(server_id, block_device[:device_name])
+            volumes.get(block_device[:volume_id]).attach(server_id, block_device[:device_name])
           end
 
           self.data[:last_modified][:servers][server_id] = Time.now


### PR DESCRIPTION
Found a bug in create_server which is not detected by Shindo
because of helper method overlap