### PR TITLE
add query to nova limits

### DIFF
--- a/gemfiles/Gemfile-1.9
+++ b/gemfiles/Gemfile-1.9
@@ -16,4 +16,5 @@ group :development, :test do
   gem "minitest"
   gem "vcr"
   gem "webmock",         "~> 1.24.6"
+  gem "json",            "< 2.0"
 end

--- a/lib/fog/openstack/requests/compute/get_limits.rb
+++ b/lib/fog/openstack/requests/compute/get_limits.rb
@@ -1,20 +1,21 @@
 module Fog
   module Compute
     class OpenStack
-      # http://docs.openstack.org/api/openstack-compute/2/content/ProgramaticLimits.html
-      #
+      # http://developer.openstack.org/api-ref-compute-v2.1.html#showlimits
+
       class Real
-        def get_limits
+        def get_limits(options = {})
           request(
-            :expects  => 200,
-            :method   => 'GET',
-            :path     => '/limits.json'
+            :expects => 200,
+            :method  => 'GET',
+            :path    => '/limits',
+            :query   => options
           )
         end
       end
 
       class Mock
-        def get_limits
+        def get_limits(_options = {})
           rate_limits = [
             { 'regex' => '.*',
               'limit' => [


### PR DESCRIPTION
with sufficient permissions you can query for `tenant_id` to get the limits of other projects