### PR TITLE
Passing an empty hash clears the external gateway.

### DIFF
--- a/lib/fog/openstack/requests/network/update_router.rb
+++ b/lib/fog/openstack/requests/network/update_router.rb
@@ -22,7 +22,7 @@ module Fog
               Fog::Logger.deprecation "Passing a model objects into options[:external_gateway_info] is deprecated. \
               Please pass  external external gateway as follows options[:external_gateway_info] = { :network_id => NETWORK_ID }]"
               data['router'][:external_gateway_info] = { :network_id => egi.id }
-            elsif egi.is_a?(Hash) and egi[:network_id]
+            elsif egi.is_a?(Hash)
               data['router'][:external_gateway_info] = egi
             else
               raise ArgumentError.new('Invalid external_gateway_info attribute')


### PR DESCRIPTION
This is an interesting one.

If you set debugging on with the openstack CLI tool and request to clear a router's external gateway then it achieves this by setting the router's `external_gateway_info` to `{}`.

As such, mandating the inclusion of a `network_id` breaks this ability, even if you set the `network_id` to empty string (you get an API validation error).