### PR TITLE
Fix stack create action

### DIFF
--- a/lib/fog/openstack/models/orchestration/templates.rb
+++ b/lib/fog/openstack/models/orchestration/templates.rb
@@ -28,7 +28,7 @@ module Fog
           end
 
           new(data)
-        rescue Fog::Compute::OpenStack::NotFound
+        rescue Fog::Orchestration::OpenStack::NotFound
           nil
         end
 

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -131,10 +131,9 @@ module Fog
       class Real
         include Fog::OpenStack::Core
 
-        # NOTE: uncommenting this should be treated as api-change!
-        # def self.not_found_class
-        #   Fog::Orchestration::OpenStack::NotFound
-        # end
+        def self.not_found_class
+          Fog::Orchestration::OpenStack::NotFound
+        end
 
         def initialize(options={})
           initialize_identity options


### PR DESCRIPTION
Fix stck create action, getting not found on template, when
stack has not been created yet. Brought by:
https://github.com/fog/fog-openstack/pull/147