### PR TITLE
template and template_url cannot appear at the same time, even though…

### DIFF
--- a/lib/fog/openstack/models/orchestration/stack.rb
+++ b/lib/fog/openstack/models/orchestration/stack.rb
@@ -104,14 +104,14 @@ module Fog
             else
               template
             end
-
-          {
+          options = {
             :stack_name       => stack_name,
             :disable_rollback => disable_rollback,
-            :template_url     => @template_url,
-            :template         => template_content,
             :timeout_mins     => timeout_mins
           }
+          options[:template] = template_content if template_content
+          options[:template_url] = @template_url if @template_url
+          options
         end
         private :default_options
       end


### PR DESCRIPTION
the default_options sets both template and template_url, but heat takes the template and ignore the template_url although it is null. So I change to only to set the template / template_url when it is not null.