### PR TITLE
remove default_options in #save

### DIFF
--- a/lib/fog/openstack/models/orchestration/stack.rb
+++ b/lib/fog/openstack/models/orchestration/stack.rb
@@ -15,9 +15,9 @@ module Fog
 
         def save(options={})
           if persisted?
-            service.update_stack(self, default_options.merge(options)).body['stack']
+            service.update_stack(self, options).body['stack']
           else
-            service.stacks.create(default_options.merge(options))
+            service.stacks.create(options)
           end
         end
 
@@ -98,8 +98,18 @@ module Fog
 
         # build options to create or update stack
         def default_options
+          template_content =
+            if template && template.is_a?(Fog::Orchestration::OpenStack::Template)
+              template.content
+            else
+              template
+            end
+
           {
             :stack_name       => stack_name,
+            :disable_rollback => disable_rollback,
+            :template_url     => @template_url,
+            :template         => template_content,
             :timeout_mins     => timeout_mins
           }
         end

--- a/lib/fog/openstack/models/orchestration/stack.rb
+++ b/lib/fog/openstack/models/orchestration/stack.rb
@@ -100,7 +100,6 @@ module Fog
         def default_options
           {
             :stack_name       => stack_name,
-            :disable_rollback => disable_rollback,
             :timeout_mins     => timeout_mins
           }
         end

--- a/lib/fog/openstack/models/orchestration/stack.rb
+++ b/lib/fog/openstack/models/orchestration/stack.rb
@@ -98,18 +98,9 @@ module Fog
 
         # build options to create or update stack
         def default_options
-          template_content =
-            if template && template.is_a?(Fog::Orchestration::OpenStack::Template)
-              template.content
-            else
-              template
-            end
-
           {
             :stack_name       => stack_name,
             :disable_rollback => disable_rollback,
-            :template_url     => @template_url,
-            :template         => template_content,
             :timeout_mins     => timeout_mins
           }
         end


### PR DESCRIPTION
when using save to create stacks with "template_url", it causes error because default_opotions have a template: null. Heat API takes template over template_url even if it is null. This default options is used for those deprecated methods such as #template=() etc. But for #save(), we do not need the default_options because it prevents us from setting our now option values. @mdarby @geemus @tokengeek @icco @dhague, @Ladas, @seanhandley and @jjasghar Do you guys have time to approve this pull request?