### PR TITLE
Fixed retrieve_tokens_v2 bug (added X-Auth-Token).

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -340,11 +340,13 @@ module Fog
 
       identity_v2_connection = Fog::Core::Connection.new(uri.to_s, false, connection_options)
       request_body = {:auth => Hash.new}
+      request_headers = {'Content-Type' => 'application/json'}
 
       if auth_token
         request_body[:auth][:token] = {
           :id => auth_token
         }
+        request_headers['X-Auth-Token'] = auth_token
       else
         request_body[:auth][:passwordCredentials] = {
           :username => username,
@@ -355,7 +357,7 @@ module Fog
 
       request = {
         :expects => [200, 204],
-        :headers => {'Content-Type' => 'application/json'},
+        :headers => request_headers,
         :body    => Fog::JSON.encode(request_body),
         :method  => 'POST',
         :path    => (uri.path and not uri.path.empty?) ? uri.path : 'v2.0'


### PR DESCRIPTION
Fixed this error when try to connect to OVH:

```
{:expects=>[200, 204], :headers=>{"Content-Type"=>"application/json"}, :body=>"{\"auth\":{\"token\":{\"id\":\"XXXXXXXXXXXXX\"},\"tenantName\":\"YYYYYYY\"}}", :method=>"POST", :path=>"/v2.0/tokens"}
#<Excon::Connection:7fb453e9ef30 @data={:...} @socket_key="https://auth.cloud.ovh.net:443">
Exiting
/home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/excon-0.51.0/lib/excon/middlewares/expects.rb:6:in `response_call': Expected([200, 204]) <=> Actual(401 Unauthorized) (Excon::Error::Unauthorized)
excon.error.response
  :body          => "{\"error\": {\"message\": \"The request you have made requires authentication.\", \"code\": 401, \"title\": \"Unauthorized\"}}"
  :cookies       => [
  ]
  :headers       => {
    "Connection"       => "close"
    "Content-Length"   => "114"
    "Content-Type"     => "application/json"
    "Date"             => "Fri, 05 Aug 2016 07:36:50 GMT"
    "Vary"             => "X-Auth-Token"
    "Www-Authenticate" => "Keystone uri=\"https://auth.cloud.ovh.net\""
  }
  :host          => "auth.cloud.ovh.net"
  :local_address => "192.168.1.110"
  :local_port    => 50353
  :path          => "/v2.0/tokens"
  :port          => 443
  :reason_phrase => "Unauthorized"
  :remote_ip     => "5.39.10.93"
  :status        => 401
  :status_line   => "HTTP/1.1 401 Unauthorized\r\n"
:status_line   => "HTTP/1.1 401 Unauthorized\r\n"
    from /home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/excon-0.51.0/lib/excon/middlewares/response_parser.rb:8:in `response_call'
    from /home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/excon-0.51.0/lib/excon/connection.rb:389:in `response'
    from /home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/excon-0.51.0/lib/excon/connection.rb:253:in `request'
    from /home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/fog-core-1.42.0/lib/fog/core/connection.rb:84:in `request'
    from /home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/fog-openstack-0.1.10/lib/fog/openstack.rb:365:in `retrieve_tokens_v2'
    from /home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/fog-openstack-0.1.10/lib/fog/openstack.rb:163:in `authenticate_v2'
    from /home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/fog-openstack-0.1.10/lib/fog/openstack.rb:97:in `authenticate'
    from /home/rjurado/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/fog-openstack-0.1.10/lib/fog/openstack/core.rb:139:in `authenticate'
...
```
