### PR TITLE
Fix endpoint version lookup

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -513,9 +513,10 @@ module Fog
       body = Fog::JSON.decode(response.body)
       version = nil
       unless body['versions'].empty?
-        supported_version = body['versions'].find do |x|
+        versions = body['versions'].kind_of?(Array) ? body['versions'] : body['versions']['values']
+        supported_version = versions.find do |x|
           x["id"].match(supported_versions) &&
-              (x["status"] == "CURRENT" || x["status"] == "SUPPORTED")
+            (x["status"] == "CURRENT" || x["status"] == "SUPPORTED" || x["status"] == "stable")
         end
         version = supported_version["id"] if supported_version
       end


### PR DESCRIPTION
Ceilometer failed on getting version from endpoint. Adapted to do not fail.

Error details: http://paste.openstack.org/show/552424/