### PR TITLE
[wip] Add Glance v2 image download Content-Range support

### DIFF
--- a/lib/fog/image/openstack/v2/requests/download_image.rb
+++ b/lib/fog/image/openstack/v2/requests/download_image.rb
@@ -3,12 +3,16 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def download_image(image_id, _content_range = nil, params) # TODO: implement content range handling
+          def download_image(image_id, content_range = nil, params)
+            headers = {}
+            headers["Content-Range"] = content_range if content_range
+
             request_hash = {
               :expects  => [200, 204],
               :method   => 'GET',
               :raw_body => true,
               :path     => "images/#{image_id}/file",
+              :headers  => headers,
             }
             request_hash[:response_block] = params[:response_block] if params[:response_block]
             request(request_hash).body


### PR DESCRIPTION
This implements Content-range support for the Glance v2 image download API in the most basic way, maintaining the placeholder function signature that was already there.

@Ladas  This should probably be more user friendly, maybe with `offset` and `chunk_size` parameters instead of just taking the raw header value, but I wanted to get some opinions before doing anything fancy. Also, what is this project's preferred way of testing a change like this?
