### PR TITLE
Fix introspection service lookup

### DIFF
--- a/lib/fog/introspection/openstack.rb
+++ b/lib/fog/introspection/openstack.rb
@@ -80,7 +80,7 @@ module Fog
         def initialize(options = {})
           initialize_identity options
 
-          @openstack_service_type  = options[:openstack_service_type] || ['introspection']
+          @openstack_service_type  = options[:openstack_service_type] || ['baremetal-introspection']
           @openstack_service_name  = options[:openstack_service_name]
 
           @connection_options = options[:connection_options] || {}
@@ -94,12 +94,7 @@ module Fog
 
         def set_api_path
           unless @path.match(SUPPORTED_VERSIONS)
-            @path = "/" + Fog::OpenStack.get_supported_version(
-              SUPPORTED_VERSIONS,
-              @openstack_management_uri,
-              @auth_token,
-              @connection_options
-            )
+            @path = "/v1"
           end
         end
       end


### PR DESCRIPTION
Upstream, the service is registered as "baremetal-introspection"
as the service type name. Setting the service type name manually
produced resulted in an error in set_api_path because it could not
find a supported version.

This patch changes the type from "introspection" to
"baremetal-introspection". It also explicitly sets the api path to
v1 because the version reported by the introspection api is 1.6
which leads Fog::OpenStack.get_supported_version to throw an error.