### PR TITLE
[DNS] add models for zone + recordset incl spec

### DIFF
--- a/lib/fog/dns/openstack/v2.rb
+++ b/lib/fog/dns/openstack/v2.rb
@@ -18,6 +18,12 @@ module Fog
                    :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
                    :openstack_identity_prefix, :openstack_temp_url_key, :openstack_cache_ttl
 
+        model_path 'fog/dns/openstack/v2/models'
+        model       :zone
+        collection  :zones
+        model       :recordset
+        collection  :recordsets
+
         request_path 'fog/dns/openstack/v2/requests'
 
         request :list_zones
@@ -34,6 +40,20 @@ module Fog
 
         request :get_quota
         request :update_quota
+
+        def self.setup_headers(options)
+          # user needs to have admin privileges to ask for all projects
+          all_projects = options.delete(:all_projects) || false
+
+          # user needs to have admin privileges to impersonate another project
+          # don't ask for all and one project at the same time
+          project_id = options.delete(:project_id) unless all_projects
+
+          headers = {'X-Auth-All-Projects' => all_projects}
+          headers['X-Auth-Sudo-Project-Id'] = project_id unless project_id.nil?
+
+          [headers, options]
+        end
 
         class Mock
           def self.data

--- a/lib/fog/dns/openstack/v2/models/recordset.rb
+++ b/lib/fog/dns/openstack/v2/models/recordset.rb
@@ -1,0 +1,55 @@
+require 'fog/openstack/models/model'
+
+module Fog
+  module DNS
+    class OpenStack
+      class V2
+        class Recordset < Fog::OpenStack::Model
+          identity :id
+
+          attribute :name
+          attribute :project_id
+          attribute :status
+          attribute :action
+          attribute :zone_id
+          attribute :zone_name
+          attribute :type
+          attribute :records
+          attribute :version
+          attribute :created_at
+          attribute :links
+
+          attribute :ttl
+          attribute :description
+          attribute :updated_at
+
+          def save
+            raise Fog::Errors::Error, 'Resaving an existing object may create a duplicate' if persisted?
+            requires :zone_id, :name, :type, :records
+            merge_attributes(service.create_recordset(zone_id, name, type, records, attributes).body)
+            true
+          end
+
+          # overwritten because zone_id is needed for get
+          def reload(options = {})
+            requires :zone_id, :id
+            merge_attributes(collection.get(zone_id, id, options).attributes)
+            self
+          end
+
+          def update(options = nil)
+            requires :zone_id, :id
+            merge_attributes(service.update_recordset(zone_id, id, options || attributes).body)
+            self
+          end
+
+          def destroy(options = {})
+            requires :zone_id, :id
+            service.delete_recordset(zone_id, id, options)
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/dns/openstack/v2/models/recordsets.rb
+++ b/lib/fog/dns/openstack/v2/models/recordsets.rb
@@ -1,0 +1,30 @@
+require 'fog/openstack/models/collection'
+require 'fog/dns/openstack/v2/models/recordset'
+
+module Fog
+  module DNS
+    class OpenStack
+      class V2
+        class Recordsets < Fog::OpenStack::Collection
+          model Fog::DNS::OpenStack::V2::Recordset
+
+          def all(options = {})
+            load_response(service.list_recordsets(options), 'recordsets')
+          end
+
+          def find_by_id(zone_id, id, options = {})
+            recordset_hash = service.get_recordset(zone_id, id, options).body
+            new(recordset_hash.merge(:service => service))
+          end
+
+          alias get find_by_id
+
+          def destroy(zone_id, id, options = {})
+            recordset = find_by_id(zone_id, id, options)
+            recordset.destroy
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/dns/openstack/v2/models/zone.rb
+++ b/lib/fog/dns/openstack/v2/models/zone.rb
@@ -1,0 +1,50 @@
+require 'fog/openstack/models/model'
+
+module Fog
+  module DNS
+    class OpenStack
+      class V2
+        class Zone < Fog::OpenStack::Model
+          identity :id
+
+          attribute :name
+          attribute :email
+          attribute :pool_id
+          attribute :project_id
+          attribute :serial
+          attribute :status
+          attribute :action
+          attribute :masters
+          attribute :version
+          attribute :links
+          attribute :created_at
+          attribute :transfered_at
+
+          attribute :ttl
+          attribute :description
+          attribute :type
+          attribute :updated_at
+
+          def save
+            raise Fog::Errors::Error, 'Resaving an existing object may create a duplicate' if persisted?
+            requires :name, :email
+            merge_attributes(service.create_zone(name, email, attributes).body)
+            true
+          end
+
+          def update(options = nil)
+            requires :id
+            merge_attributes(service.update_zone(id, options || attributes).body)
+            self
+          end
+
+          def destroy(options = {})
+            requires :id
+            service.delete_zone(id, options)
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/dns/openstack/v2/models/zones.rb
+++ b/lib/fog/dns/openstack/v2/models/zones.rb
@@ -1,0 +1,30 @@
+require 'fog/openstack/models/collection'
+require 'fog/dns/openstack/v2/models/zone'
+
+module Fog
+  module DNS
+    class OpenStack
+      class V2
+        class Zones < Fog::OpenStack::Collection
+          model Fog::DNS::OpenStack::V2::Zone
+
+          def all(options = {})
+            load_response(service.list_zones(options), 'zones')
+          end
+
+          def find_by_id(id, options = {})
+            zone_hash = service.get_zone(id, options).body
+            new(zone_hash.merge(:service => service))
+          end
+
+          alias get find_by_id
+
+          def destroy(id, options = {})
+            zone = find_by_id(id, options)
+            zone.destroy
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/dns/openstack/v2/requests/delete_recordset.rb
+++ b/lib/fog/dns/openstack/v2/requests/delete_recordset.rb
@@ -3,17 +3,19 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def delete_recordset(zone_id, id)
+          def delete_recordset(zone_id, id, options = {})
+            headers, _options = Fog::DNS::OpenStack::V2.setup_headers(options)
             request(
               :expects => 202,
               :method  => 'DELETE',
-              :path    => "zones/#{zone_id}/recordsets/#{id}"
+              :path    => "zones/#{zone_id}/recordsets/#{id}",
+              :headers => headers
             )
           end
         end
 
         class Mock
-          def delete_recordset(zone_id, id)
+          def delete_recordset(zone_id, id, _options = {})
             response = Excon::Response.new
             response.status = 202
 

--- a/lib/fog/dns/openstack/v2/requests/delete_zone.rb
+++ b/lib/fog/dns/openstack/v2/requests/delete_zone.rb
@@ -3,17 +3,19 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def delete_zone(id)
+          def delete_zone(id, options = {})
+            headers, _options = Fog::DNS::OpenStack::V2.setup_headers(options)
             request(
               :expects => 202,
               :method  => 'DELETE',
-              :path    => "zones/#{id}"
+              :path    => "zones/#{id}",
+              :headers => headers
             )
           end
         end
 
         class Mock
-          def delete_zone(id)
+          def delete_zone(id, _options = {})
             response = Excon::Response.new
             response.status = 202
 

--- a/lib/fog/dns/openstack/v2/requests/get_quota.rb
+++ b/lib/fog/dns/openstack/v2/requests/get_quota.rb
@@ -4,11 +4,13 @@ module Fog
       class V2
         class Real
           def get_quota(project_id = nil)
+            headers, _options = Fog::DNS::OpenStack::V2.setup_headers(:all_projects => !project_id.nil?)
+
             request(
-              :headers => {"X-Auth-All-Projects" => !project_id.nil?},
               :expects => 200,
               :method  => 'GET',
-              :path    => "quotas/#{project_id}"
+              :path    => "quotas/#{project_id}",
+              :headers => headers
             )
           end
         end

--- a/lib/fog/dns/openstack/v2/requests/get_recordset.rb
+++ b/lib/fog/dns/openstack/v2/requests/get_recordset.rb
@@ -3,11 +3,13 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def get_recordset(zone_id, id)
+          def get_recordset(zone_id, id, options = {})
+            headers, _options = Fog::DNS::OpenStack::V2.setup_headers(options)
             request(
               :expects => 200,
               :method  => 'GET',
-              :path    => "zones/#{zone_id}/recordsets/#{id}"
+              :path    => "zones/#{zone_id}/recordsets/#{id}",
+              :headers => headers
             )
           end
         end

--- a/lib/fog/dns/openstack/v2/requests/get_zone.rb
+++ b/lib/fog/dns/openstack/v2/requests/get_zone.rb
@@ -3,17 +3,19 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def get_zone(id)
+          def get_zone(id, options = {})
+            headers, _options = Fog::DNS::OpenStack::V2.setup_headers(options)
             request(
               :expects => 200,
               :method  => 'GET',
-              :path    => "zones/#{id}"
+              :path    => "zones/#{id}",
+              :headers => headers
             )
           end
         end
 
         class Mock
-          def get_zone(id)
+          def get_zone(id, _options = {})
             response = Excon::Response.new
             response.status = 200
             zone = data[:zone_updated] || data[:zones].first

--- a/lib/fog/dns/openstack/v2/requests/list_recordsets.rb
+++ b/lib/fog/dns/openstack/v2/requests/list_recordsets.rb
@@ -3,22 +3,46 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def list_recordsets(zone_id, options = {})
+          def list_recordsets(zone_id = nil, options = {})
+            # for backward compatability: consider removing the zone_id param (breaking change)
+            unless zone_id.nil?
+              if zone_id.kind_of?(Hash)
+                options = zone_id
+                zone_id = nil
+              else
+                Fog::Logger.deprecation(
+                  'Calling list_recordsets(zone_id) is deprecated, use .list_recordsets(zone_id: value) instead'
+                )
+              end
+            end
+
+            zone_id = options.delete(:zone_id) if zone_id.nil?
+            path = zone_id.nil? ? 'recordsets' : "zones/#{zone_id}/recordsets"
+
+            headers, options = Fog::DNS::OpenStack::V2.setup_headers(options)
+
             request(
               :expects => 200,
               :method  => 'GET',
-              :path    => "zones/#{zone_id}/recordsets",
-              :query   => options
+              :path    => path,
+              :query   => options,
+              :headers => headers
             )
           end
         end
 
         class Mock
-          def list_recordsets(zone_id, _options = {})
+          def list_recordsets(zone_id = nil, options = {})
+            if zone_id.kind_of?(Hash)
+              options = zone_id
+              zone_id = nil
+            end
+            zone_id = options.delete(:zone_id) if zone_id.nil?
+
             response = Excon::Response.new
             response.status = 200
             data[:recordsets]["recordsets"].each do |rs|
-              rs["zone_id"] = zone_id
+              rs["zone_id"] = zone_id unless zone_id.nil?
             end
             response.body = data[:recordsets]
             response

--- a/lib/fog/dns/openstack/v2/requests/list_zones.rb
+++ b/lib/fog/dns/openstack/v2/requests/list_zones.rb
@@ -4,11 +4,14 @@ module Fog
       class V2
         class Real
           def list_zones(options = {})
+            headers, options = Fog::DNS::OpenStack::V2.setup_headers(options)
+
             request(
               :expects => 200,
               :method  => 'GET',
               :path    => 'zones',
-              :query   => options
+              :query   => options,
+              :headers => headers
             )
           end
         end

--- a/lib/fog/dns/openstack/v2/requests/update_quota.rb
+++ b/lib/fog/dns/openstack/v2/requests/update_quota.rb
@@ -4,13 +4,14 @@ module Fog
       class V2
         class Real
           def update_quota(project_id, options = {})
-            all_projects = options.key?(:all_projects) ? options.delete(:all_projects) : false
+            headers, options = Fog::DNS::OpenStack::V2.setup_headers(options)
+
             request(
-              :headers => {"X-Auth-All-Projects" => all_projects},
               :body    => Fog::JSON.encode(options),
               :expects => 200,
               :method  => 'PATCH',
-              :path    => "quotas/#{project_id}"
+              :path    => "quotas/#{project_id}",
+              :headers => headers
             )
           end
         end

--- a/lib/fog/dns/openstack/v2/requests/update_recordset.rb
+++ b/lib/fog/dns/openstack/v2/requests/update_recordset.rb
@@ -4,11 +4,14 @@ module Fog
       class V2
         class Real
           def update_recordset(zone_id, id, options = {})
+            headers, options = Fog::DNS::OpenStack::V2.setup_headers(options)
+
             request(
               :body    => Fog::JSON.encode(options),
               :expects => 202,
               :method  => 'PUT',
-              :path    => "zones/#{zone_id}/recordsets/#{id}"
+              :path    => "zones/#{zone_id}/recordsets/#{id}",
+              :headers => headers
             )
           end
         end

--- a/lib/fog/dns/openstack/v2/requests/update_zone.rb
+++ b/lib/fog/dns/openstack/v2/requests/update_zone.rb
@@ -4,11 +4,14 @@ module Fog
       class V2
         class Real
           def update_zone(id, options = {})
+            headers, options = Fog::DNS::OpenStack::V2.setup_headers(options)
+
             request(
               :body    => Fog::JSON.encode(options),
               :expects => 202,
               :method  => 'PATCH',
-              :path    => "zones/#{id}"
+              :path    => "zones/#{id}",
+              :headers => headers
             )
           end
         end

--- a/spec/dns_v2_spec.rb
+++ b/spec/dns_v2_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require_relative './shared_context'
+
+describe Fog::DNS::OpenStack::V2 do
+  spec_data_folder = 'spec/fixtures/openstack/dns_v2'
+
+  before :all do
+    openstack_vcr = OpenStackVCR.new(
+      :vcr_directory  => spec_data_folder,
+      :project_scoped => true,
+      :service_class  => Fog::DNS::OpenStack # Fog to choose latest available version
+    )
+    @service = openstack_vcr.service
+  end
+
+  it "CRUD & list zones" do
+    VCR.use_cassette('zone_crud') do
+      zone = 'example.org'
+      zone_name = "#{zone}."
+      zone_description = 'fog testing'
+
+      begin
+        # create zone
+        example_zone = @service.zones.create(:name => zone_name, :email => "hostmaster@#{zone}")
+        example_zone.status.must_equal 'PENDING'
+        example_zone.action.must_equal 'CREATE'
+        example_id = example_zone.id
+
+        # add a description
+        example_zone.update(:description => zone_description)
+        example_zone.reload.description.must_equal zone_description
+
+        # get by ID
+        example_zone_by_id = @service.zones.find_by_id example_id
+        example_zone_by_id.wont_equal nil
+        example_zone_by_id.description.must_equal zone_description
+
+        # get by filtering list by name
+        zones = @service.zones.all(:name => zone_name)
+        zones.length.must_equal 1
+        zones.first.id.must_equal example_id
+      ensure
+        # delete the zone(s)
+        @service.zones.all(:name => zone_name).each(&:destroy)
+
+        # check delete action
+        @service.zones.all(:name => zone_name).each do |z|
+          z.action.must_equal 'DELETE'
+        end
+      end
+    end
+  end
+
+  it "CRUD & list recordsets" do
+    VCR.use_cassette('recordset_crud') do
+      zone = 'example2.org'
+      zone_name = "#{zone}."
+      recordset_name = "host.#{zone_name}"
+      records = ['10.0.0.1']
+      records_updated = ['10.0.0.2']
+
+      begin
+        # create zone
+        example_zone = @service.zones.create(:name => zone_name, :email => "hostmaster@#{zone}")
+        example_id = example_zone.id
+
+        # create recordset
+        host_record = @service.recordsets.create(
+          :zone_id => example_id,
+          :name    => recordset_name,
+          :type    => 'A',
+          :records => records
+        )
+        host_id = host_record.id
+
+        # change record
+        host_record.update(:records => records_updated)
+        host_record.reload.records.must_equal records_updated
+
+        # get by ID
+        host_record_by_id = @service.recordsets.find_by_id(example_id, host_id)
+        host_record_by_id.wont_equal nil
+        host_record_by_id.records.must_equal records_updated
+
+        # get by filtering list by name
+        recordsets = @service.recordsets.all(:zone_id => example_id, :name => recordset_name)
+        recordsets.length.must_equal 1
+        recordsets.first.id.must_equal host_id
+      ensure
+        # delete the recordset(s)
+        @service.recordsets.all(:zone_id => example_id, :name => recordset_name).each(&:destroy)
+        # delete the zone(s)
+        @service.zones.all(:name => zone_name).each(&:destroy)
+      end
+    end
+  end
+end

--- a/spec/fixtures/openstack/dns_v2/common_setup.yml
+++ b/spec/fixtures/openstack/dns_v2/common_setup.yml
@@ -1,0 +1,207 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://devstack.openstack.stack:5000/v3/auth/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password","domain":{"name":"Default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"name":"Default"}}}}}'
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-424208f4-a2cb-4690-8853-b3147c4e7ed9
+      Vary:
+      - X-Auth-Token
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+      Date:
+      - Mon, 05 Sep 2016 09:31:30 GMT
+      X-Subject-Token:
+      - 833aba07925148f9bac2bc047e858727
+      Server:
+      - nginx/1.11.1
+    body:
+      encoding: UTF-8
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "d1c1cd5484214574bb4fbc6595def9a6",
+        "name": "admin"}],
+        "expires_at": "2016-09-05T10:31:30.350767Z", "project": {"domain": {"id":
+        "ca1b267e149d4e44bf53d28d1c8d6bc9", "name": "Default"}, "id": "c60a441e54cd435896a357026aa4050a",
+        "name": "admin"}, "catalog": [{"endpoints": [{"url": "https://devstack.openstack.stack:8786/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "2f0623e5f9204d83931fd57a1fdb1123"}, {"url": "http://devstack.openstack.stack:8786/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "988f5ca2e8de446db6a36f54045efeac"}, {"url": "http://devstack.openstack.stack:8786/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "127042e3843d4fb9b62a79633f95ba15"}],
+        "type": "sharev2", "id": "999ab682b1da4982ac2eaa6d16e2f620", "name": "manilav2"}, {"endpoints":
+        [{"url": "http://devstack.openstack.stack:6385", "interface": "public",
+        "region": "RegionOne", "region_id": "RegionOne", "id": "316493ea520142ca98dd3e1d30beb7b5"},
+        {"url": "http://devstack.openstack.stack:6385",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "d6fa2fe8b1fa434b883fe3328fbdbda5"}, {"url": "http://devstack.openstack.stack:6385",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "0a97f39ddae1412e97a5f21b4432e9a8"}],
+        "type": "baremetal", "id": "93bf146f641b42a1b28c22b64ad0e23d", "name": "ironic"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:9311", "interface":
+        "public", "region": "RegionOne", "region_id": "RegionOne", "id": "43e287df110b4889a34eecbacdbd8a41"},
+        {"url": "http://devstack.openstack.stack:9311",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "cc6e3f6b47de4213bdf663675baa4f86"}, {"url": "http://devstack.openstack.stack:9311",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "461849e8b3a342d3a291506e1985b08d"}],
+        "type": "key-manager", "id": "08c811648b504ca2b2cfd88a2a07f194", "name": "barbican"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:8776/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "52846c1572cf4f7b9074584fd5e9495d"}, {"url": "http://devstack.openstack.stack:8776/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "0ff5e424c17b4f2fb1aec59abfa482e3"}, {"url": "http://devstack.openstack.stack:8776/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "ecd9d544e4304d53929a1d9befe1eb7a"}],
+        "type": "volumev2", "id": "defd346d6cb145bc8c6dde484ff96e91", "name": "cinderv2"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:6001/v1/AUTH_c60a441e54cd435896a357026aa4050a",
+        "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "a6ee953c5fc04fd48363c3aaaf469f17"}, {"url": "https://devstack.openstack.stack:6001/v1/AUTH_c60a441e54cd435896a357026aa4050a",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "8ae55154d72c45ac825ad17a5d2fe941"}, {"url": "https://devstack.openstack.stack:6001/v1",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "4b9b0916e18c4757bd42cf29d449754e"}],
+        "type": "object-store", "id": "857f8a01ba7d40399d7d3657c72b500e", "name":
+        "swift"}, {"endpoints": [{"url": "https://devstack.openstack.stack:9292",
+        "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "5338ffd565884035941ec3be3ad9002d"}, {"url": "http://devstack.openstack.stack:9292",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "81c0b570c44b4a978eb58a28e605f928"}, {"url": "http://devstack.openstack.stack:9292",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "c3967eb5b037433894e33218e6e953bb"}],
+        "type": "image", "id": "1db038028295470499be817ca0880dbc", "name": "glance"},
+        {"endpoints": [{"url": "http://devstack.openstack.stack:8070/v2.0",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "099c924a40da4862885ab324be95904f"}, {"url": "https://devstack.openstack.stack:8070/v2.0",
+        "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "011d8cb4bd9a4917a6022c93fd105922"}, {"url": "https://devstack.openstack.stack:8070/v2.0",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "6f06c9fb62ee48a1b63cc77b2bf89ae1"}],
+        "type": "monitoring", "id": "6f674669b6a04e15b1d1a97366b00395", "name": "monasca"},
+        {"endpoints": [{"url": "http://devstack.openstack.stack:8777", "interface":
+        "public", "region": "RegionOne", "region_id": "RegionOne", "id": "21e8e980f4a24731baeaea9b7a9a69d6"},
+        {"url": "http://devstack.openstack.stack:8777", "interface": "internal",
+        "region": "RegionOne", "region_id": "RegionOne", "id": "2ceaea4ea02746e2a8f5b98c6cae6868"},
+        {"url": "http://devstack.openstack.stack:8777", "interface": "admin",
+        "region": "RegionOne", "region_id": "RegionOne", "id": "7b35b996c1024b78951af72248bf96e5"}],
+        "type": "metering", "id": "621f5f04ac2248ec92f12edc8e941fde", "name": "ceilometer"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:8774/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "383c3adc7a334d1e89f3d824167b4ad2"}, {"url": "http://devstack.openstack.stack:8774/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "f92bf0dad1e941d09d9a08cb50362510"}, {"url": "http://devstack.openstack.stack:8774/v2/c60a441e54cd435896a357026aa4050a",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "da09586d8bb44903a53efcebe67841d9"}],
+        "type": "compute", "id": "45b131798dc240c4b5d75e024dffc5b5", "name": "nova"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:5000/v3", "interface":
+        "public", "region": "RegionOne", "region_id": "RegionOne", "id": "7859f84c67d740b294c9a607d03c2991"},
+        {"url": "http://devstack.openstack.stack:5000/v3",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "a2cff5bcad944eb4a10c06e6c05140eb"}, {"url": "devstack.openstack.stack:5000/v3",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "5973c23918b8460886140c5ed6a5411b"}],
+        "type": "identity", "id": "70c56d9a4833404e823ba1195a0f1a63", "name": "keystone"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:8786/v1/c60a441e54cd435896a357026aa4050a",
+        "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "aa42c3a4f7b54d95819fc6481626cedc"}, {"url": "http://devstack.openstack.stack:8786/v1/c60a441e54cd435896a357026aa4050a",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "68abd86060354f83932f7d283339eff1"}, {"url": "http://devstack.openstack.stack:8786/v1/c60a441e54cd435896a357026aa4050a",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "52450fbc1b4e48cda51bb5e58ab4b15f"}],
+        "type": "share", "id": "56626b3178214332873f8a277b497e3e", "name": "manila"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:8776/v1/c60a441e54cd435896a357026aa4050a",
+        "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "6f338859ed944a10937bee3e2a580f22"}, {"url": "http://devstack.openstack.stack:8776/v1/c60a441e54cd435896a357026aa4050a",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "ef38079803a548dfb1937e363b404e23"}, {"url": "http://devstack.openstack.stack:8776/v1/c60a441e54cd435896a357026aa4050a",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "4bf258d657234ceaa573f02cc5203895"}],
+        "type": "volume", "id": "e967f0a7931e49a4b235239f4fc0ed0e", "name": "cinder"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:9696", "interface":
+        "public", "region": "RegionOne", "region_id": "RegionOne", "id": "12c7b0cb1f804325bd025fb32d8c33e7"},
+        {"url": "http://devstack.openstack.stack:9696",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "a4e60839ebf54e02a6202c164cbc6a6e"}, {"url": "http://devstack.openstack.stack:9696",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "9ad2510072024ecf8363c9d18eb4b431"}],
+        "type": "network", "id": "5841d2e972ff44fdb1c789d5261f7318", "name": "neutron"},
+        {"endpoints": [{"url": "https://devstack.openstack.stack:9001", "interface":
+        "public", "region": "RegionOne", "region_id": "RegionOne", "id": "692e55cfdb704300967c7da0c55a43bb"},
+        {"url": "https://devstack.openstack.stack:9001",
+        "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id":
+        "bcfa65f36471406f88b89706274d4465"}, {"url": "https://devstack.openstack.stack:9001",
+        "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "57f2b925603f4541b421bea815001b22"}],
+        "type": "dns", "id": "1010a70e914348b59999eefc25b30e7d", "name": "designate"}], "user": {"domain": {"id": "ca1b267e149d4e44bf53d28d1c8d6bc9",
+        "name": "Default"}, "id": "c967b8ba7651e623e91733b25b5834589c48ea6ea826219494316be042429a00",
+        "name": "admin"}, "audit_ids": ["ZlcDBHPjSeyD83V0v2zgew"], "issued_at":
+        "2016-09-05T09:31:30.350795Z"}}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 09:31:30 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 09:31:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '461'
+      Connection:
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "versions": {
+            "values": [
+              {
+                "id": "v1",
+                "links": [
+                  {
+                    "href": "https://devstack.openstack.stack:9001/v1",
+                    "rel": "self"
+                  }
+                ],
+                "status": "DEPRECATED"
+              },
+              {
+                "id": "v2",
+                "links": [
+                  {
+                    "href": "https://devstack.openstack.stack:9001/v2",
+                    "rel": "self"
+                  }
+                ],
+                "status": "CURRENT"
+              }
+            ]
+          }
+        }
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 09:31:30 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/openstack/dns_v2/recordset_crud.yml
+++ b/spec/fixtures/openstack/dns_v2/recordset_crud.yml
@@ -1,0 +1,472 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://devstack.openstack.stack:9001/v2/zones
+    body:
+      encoding: UTF-8
+      string: '{"name":"example2.org.","email":"hostmaster@example2.org"}'
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+  response:
+    status:
+      code: 202
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:24 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '563'
+      Connection:
+      - keep-alive
+      Location:
+      - https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f
+      X-Openstack-Request-Id:
+      - req-2a73d263-46b9-43e1-b287-438d5980c52c
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "masters": [], "name": "example2.org.", "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f"},
+        "transferred_at": null, "created_at": "2016-09-05T14:56:24.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": null, "version": 1,
+        "id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f", "ttl": 3600, "action": "CREATE",
+        "attributes": {}, "serial": 1473087384, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example2.org", "description": null}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:24 GMT
+- request:
+    method: post
+    uri: https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets
+    body:
+      encoding: UTF-8
+      string: '{"name":"host.example2.org.","type":"A","records":["10.0.0.1"]}'
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+  response:
+    status:
+      code: 202
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:24 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '550'
+      Connection:
+      - keep-alive
+      Location:
+      - https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25
+      X-Openstack-Request-Id:
+      - req-90978705-6a48-4df0-8020-2afd4844c6ce
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "description": null, "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25"},
+        "created_at": "2016-09-05T14:56:24.000000", "updated_at": null, "records":
+        ["10.0.0.1"], "zone_id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f", "version":
+        1, "ttl": null, "action": "CREATE", "zone_name": "example2.org.", "project_id":
+        "c60a441e54cd435896a357026aa4050a", "type": "A", "id": "8af8ef76-2846-4077-973a-b41593bd1e25",
+        "name": "host.example2.org."}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:24 GMT
+- request:
+    method: put
+    uri: https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25
+    body:
+      encoding: UTF-8
+      string: '{"records":["10.0.0.2"]}'
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 202
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:24 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '574'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-a89b0d4f-eee3-4571-8a68-b60b5e45cf6a
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "description": null, "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25"},
+        "created_at": "2016-09-05T14:56:24.000000", "updated_at": "2016-09-05T14:56:24.000000",
+        "records": ["10.0.0.2"], "zone_id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f",
+        "version": 2, "ttl": null, "action": "UPDATE", "zone_name": "example2.org.",
+        "project_id": "c60a441e54cd435896a357026aa4050a", "type": "A", "id": "8af8ef76-2846-4077-973a-b41593bd1e25",
+        "name": "host.example2.org."}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:24 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '574'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-f23b4b01-385a-472f-bb61-8a83110b5e9f
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "description": null, "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25"},
+        "created_at": "2016-09-05T14:56:24.000000", "updated_at": "2016-09-05T14:56:24.000000",
+        "records": ["10.0.0.2"], "zone_id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f",
+        "version": 2, "ttl": null, "action": "UPDATE", "zone_name": "example2.org.",
+        "project_id": "c60a441e54cd435896a357026aa4050a", "type": "A", "id": "8af8ef76-2846-4077-973a-b41593bd1e25",
+        "name": "host.example2.org."}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:24 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '574'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-b8efb862-3230-4485-8667-ee8d5760957a
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "description": null, "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25"},
+        "created_at": "2016-09-05T14:56:24.000000", "updated_at": "2016-09-05T14:56:24.000000",
+        "records": ["10.0.0.2"], "zone_id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f",
+        "version": 2, "ttl": null, "action": "UPDATE", "zone_name": "example2.org.",
+        "project_id": "c60a441e54cd435896a357026aa4050a", "type": "A", "id": "8af8ef76-2846-4077-973a-b41593bd1e25",
+        "name": "host.example2.org."}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:25 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets?name=host.example2.org.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '763'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-f6432d09-ea08-403d-a118-c80ba3b2cf87
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"recordsets": [{"status": "PENDING", "description": null, "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25"},
+        "created_at": "2016-09-05T14:56:24.000000", "updated_at": "2016-09-05T14:56:24.000000",
+        "records": ["10.0.0.2"], "zone_id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f",
+        "version": 2, "ttl": null, "action": "UPDATE", "zone_name": "example2.org.",
+        "project_id": "c60a441e54cd435896a357026aa4050a", "type": "A", "id": "8af8ef76-2846-4077-973a-b41593bd1e25",
+        "name": "host.example2.org."}], "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets?name=host.example2.org."},
+        "metadata": {"total_count": 1}}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:25 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets?name=host.example2.org.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '763'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-06225afa-4ef3-4203-9471-fbe3a4ff9685
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"recordsets": [{"status": "PENDING", "description": null, "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25"},
+        "created_at": "2016-09-05T14:56:24.000000", "updated_at": "2016-09-05T14:56:24.000000",
+        "records": ["10.0.0.2"], "zone_id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f",
+        "version": 2, "ttl": null, "action": "UPDATE", "zone_name": "example2.org.",
+        "project_id": "c60a441e54cd435896a357026aa4050a", "type": "A", "id": "8af8ef76-2846-4077-973a-b41593bd1e25",
+        "name": "host.example2.org."}], "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets?name=host.example2.org."},
+        "metadata": {"total_count": 1}}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:25 GMT
+- request:
+    method: delete
+    uri: https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 202
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '574'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-f3975db6-2814-448b-9a8a-0891a7484096
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "description": null, "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f/recordsets/8af8ef76-2846-4077-973a-b41593bd1e25"},
+        "created_at": "2016-09-05T14:56:24.000000", "updated_at": "2016-09-05T14:56:25.000000",
+        "records": ["10.0.0.2"], "zone_id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f",
+        "version": 3, "ttl": null, "action": "DELETE", "zone_name": "example2.org.",
+        "project_id": "c60a441e54cd435896a357026aa4050a", "type": "A", "id": "8af8ef76-2846-4077-973a-b41593bd1e25",
+        "name": "host.example2.org."}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:25 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones?name=example2.org.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '718'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-da823136-97f6-4759-8f4e-10583a05638e
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"zones": [{"status": "PENDING", "masters": [], "name": "example2.org.",
+        "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f"},
+        "transferred_at": null, "created_at": "2016-09-05T14:56:24.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T14:56:25.000000",
+        "version": 4, "id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f", "ttl": 3600, "action":
+        "UPDATE", "attributes": {}, "serial": 1473087387, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example2.org", "description": null}],
+        "links": {"self": "https://devstack.openstack.stack:9001/v2/zones?name=example2.org."},
+        "metadata": {"total_count": 1}}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:25 GMT
+- request:
+    method: delete
+    uri: https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 202
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 14:56:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '587'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-3d1b4785-76ce-425a-899e-4719729102b1
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "masters": [], "name": "example2.org.", "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/afacbd2b-6cda-4a05-b4bd-1db06cb3da3f"},
+        "transferred_at": null, "created_at": "2016-09-05T14:56:24.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T14:56:25.000000",
+        "version": 5, "id": "afacbd2b-6cda-4a05-b4bd-1db06cb3da3f", "ttl": 3600, "action":
+        "DELETE", "attributes": {}, "serial": 1473087387, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example2.org", "description": null}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 14:56:25 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/openstack/dns_v2/zone_crud.yml
+++ b/spec/fixtures/openstack/dns_v2/zone_crud.yml
@@ -1,0 +1,389 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://devstack.openstack.stack:9001/v2/zones
+    body:
+      encoding: UTF-8
+      string: '{"name":"example.org.","email":"hostmaster@example.org"}'
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+  response:
+    status:
+      code: 202
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 11:26:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '561'
+      Connection:
+      - keep-alive
+      Location:
+      - https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1
+      X-Openstack-Request-Id:
+      - req-13c405d5-1ade-4755-ba2f-a2c81d5ff34d
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "masters": [], "name": "example.org.", "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1"},
+        "transferred_at": null, "created_at": "2016-09-05T11:26:25.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": null, "version": 1,
+        "id": "85735965-31a1-46f9-a429-7e410b75e8e1", "ttl": 3600, "action": "CREATE",
+        "attributes": {}, "serial": 1473074785, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example.org", "description": null}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 11:26:25 GMT
+- request:
+    method: patch
+    uri: https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1
+    body:
+      encoding: UTF-8
+      string: '{"description":"fog testing"}'
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 202
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 11:26:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '594'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-9d7c6734-7e32-4110-b053-7c4aa7027303
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "masters": [], "name": "example.org.", "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1"},
+        "transferred_at": null, "created_at": "2016-09-05T11:26:25.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T11:26:25.000000",
+        "version": 2, "id": "85735965-31a1-46f9-a429-7e410b75e8e1", "ttl": 3600, "action":
+        "UPDATE", "attributes": {}, "serial": 1473074786, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example.org", "description": "fog
+        testing"}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 11:26:25 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 11:26:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '594'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-20342c50-24c5-4ae3-8c36-f081d17ed903
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "masters": [], "name": "example.org.", "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1"},
+        "transferred_at": null, "created_at": "2016-09-05T11:26:25.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T11:26:25.000000",
+        "version": 2, "id": "85735965-31a1-46f9-a429-7e410b75e8e1", "ttl": 3600, "action":
+        "UPDATE", "attributes": {}, "serial": 1473074786, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example.org", "description": "fog
+        testing"}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 11:26:25 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 11:26:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '594'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-2f43a507-112c-433e-b479-0b1140e0081b
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "masters": [], "name": "example.org.", "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1"},
+        "transferred_at": null, "created_at": "2016-09-05T11:26:25.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T11:26:25.000000",
+        "version": 2, "id": "85735965-31a1-46f9-a429-7e410b75e8e1", "ttl": 3600, "action":
+        "UPDATE", "attributes": {}, "serial": 1473074786, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example.org", "description": "fog
+        testing"}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 11:26:25 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones?name=example.org.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 11:26:25 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '724'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-a01b0c87-b6ff-4a9d-8c21-1106967141c0
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"zones": [{"status": "PENDING", "masters": [], "name": "example.org.",
+        "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1"},
+        "transferred_at": null, "created_at": "2016-09-05T11:26:25.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T11:26:25.000000",
+        "version": 2, "id": "85735965-31a1-46f9-a429-7e410b75e8e1", "ttl": 3600, "action":
+        "UPDATE", "attributes": {}, "serial": 1473074786, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example.org", "description": "fog
+        testing"}], "links": {"self": "https://devstack.openstack.stack:9001/v2/zones?name=example.org."},
+        "metadata": {"total_count": 1}}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 11:26:25 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones?name=example.org.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 11:26:26 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '724'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-02e2858f-ca1c-4ee2-a9e4-62b7057f6a40
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"zones": [{"status": "PENDING", "masters": [], "name": "example.org.",
+        "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1"},
+        "transferred_at": null, "created_at": "2016-09-05T11:26:25.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T11:26:25.000000",
+        "version": 2, "id": "85735965-31a1-46f9-a429-7e410b75e8e1", "ttl": 3600, "action":
+        "UPDATE", "attributes": {}, "serial": 1473074786, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example.org", "description": "fog
+        testing"}], "links": {"self": "https://devstack.openstack.stack:9001/v2/zones?name=example.org."},
+        "metadata": {"total_count": 1}}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 11:26:26 GMT
+- request:
+    method: delete
+    uri: https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 202
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 11:26:26 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '594'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-907cbf36-376f-4b06-b1c1-c16620afbc9f
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"status": "PENDING", "masters": [], "name": "example.org.", "links":
+        {"self": "https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1"},
+        "transferred_at": null, "created_at": "2016-09-05T11:26:25.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T11:26:26.000000",
+        "version": 3, "id": "85735965-31a1-46f9-a429-7e410b75e8e1", "ttl": 3600, "action":
+        "DELETE", "attributes": {}, "serial": 1473074786, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example.org", "description": "fog
+        testing"}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 11:26:26 GMT
+- request:
+    method: get
+    uri: https://devstack.openstack.stack:9001/v2/zones?name=example.org.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.40.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 833aba07925148f9bac2bc047e858727
+      X-Auth-All-Projects:
+      - 'false'
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.11.1
+      Date:
+      - Mon, 05 Sep 2016 11:26:26 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '724'
+      Connection:
+      - keep-alive
+      X-Openstack-Request-Id:
+      - req-d2d7cf1a-b5b8-4619-b441-2f827a636392
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"zones": [{"status": "PENDING", "masters": [], "name": "example.org.",
+        "links": {"self": "https://devstack.openstack.stack:9001/v2/zones/85735965-31a1-46f9-a429-7e410b75e8e1"},
+        "transferred_at": null, "created_at": "2016-09-05T11:26:25.000000", "pool_id":
+        "794ccc2c-d751-44fe-b57f-8894c9f5c842", "updated_at": "2016-09-05T11:26:26.000000",
+        "version": 3, "id": "85735965-31a1-46f9-a429-7e410b75e8e1", "ttl": 3600, "action":
+        "DELETE", "attributes": {}, "serial": 1473074786, "project_id": "c60a441e54cd435896a357026aa4050a",
+        "type": "PRIMARY", "email": "hostmaster@example.org", "description": "fog
+        testing"}], "links": {"self": "https://devstack.openstack.stack:9001/v2/zones?name=example.org."},
+        "metadata": {"total_count": 1}}'
+    http_version:
+  recorded_at: Mon, 05 Sep 2016 11:26:26 GMT
+recorded_with: VCR 3.0.1

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -47,6 +47,7 @@ class OpenStackVCR
                          Fog::Image::OpenStack,
                          Fog::Image::OpenStack::V1,
                          Fog::Network::OpenStack,
+                         Fog::DNS::OpenStack,
                          Fog::Monitoring::OpenStack].include? @service_class
                        'http://devstack.openstack.stack:5000/v3'
                      else
@@ -84,6 +85,7 @@ class OpenStackVCR
       username      = 'admin'
       # keep in sync with the token obtained in the "common_setup.yml"
       token         = '5c28403cf669414d8ee179f1e7f205ee'
+      interface     = 'adminURL'
       domain_name   = 'Default'
       @project_name = 'admin'
 
@@ -92,16 +94,18 @@ class OpenStackVCR
         password      = ENV['OS_PASSWORD']          || options[:password]     || password
         username      = ENV['OS_USERNAME']          || options[:username]     || username
         token         = ENV['OS_TOKEN']             || options[:token]        || token
+        interface     = ENV['OS_INTERFACE']         || options[:interface]    || interface
         domain_name   = ENV['OS_USER_DOMAIN_NAME']  || options[:domain_name]  || domain_name
         @project_name = ENV['OS_PROJECT_NAME']      || options[:project_name] || @project_name
       end
 
       if @service_class == Fog::Identity::OpenStack::V3 || @os_auth_url.end_with?('/v3')
         connection_options = {
-          :openstack_auth_url    => "#{@os_auth_url}/auth/tokens",
-          :openstack_region      => region,
-          :openstack_domain_name => domain_name,
-          :openstack_cache_ttl   => 0
+          :openstack_auth_url      => "#{@os_auth_url}/auth/tokens",
+          :openstack_region        => region,
+          :openstack_domain_name   => domain_name,
+          :openstack_endpoint_type => interface,
+          :openstack_cache_ttl     => 0
         }
         connection_options[:openstack_project_name] = @project_name if @with_project_scope
         connection_options[:openstack_service_type] = [ENV['OS_AUTH_SERVICE']] if ENV['OS_AUTH_SERVICE']

--- a/test/requests/dns_v2/recordset_tests.rb
+++ b/test/requests/dns_v2/recordset_tests.rb
@@ -25,24 +25,32 @@ describe "Fog::DNS::OpenStack::V2 | recordset requests" do
       "action"      => String
     }
 
-    @recordset_links_format = {
+    recordset_links_format = {
       "self" => String,
       "next" => String
     }
 
-    @recordset_metadata_format = {
+    recordset_metadata_format = {
       "total_count" => Integer
+    }
+
+    @recordset_list_format = {
+      "recordsets" => [@recordset_format],
+      "links"      => recordset_links_format,
+      "metadata"   => recordset_metadata_format
     }
   end
 
   describe "success" do
-    it "#list_recordsets" do
+    it "#list_recordsets deprecated" do
       recordset_list_body = @dns.list_recordsets(@zone_id).body
-      recordset_list_body.must_match_schema(
-        "recordsets" => [@recordset_format],
-        "links"      => @recordset_links_format,
-        "metadata"   => @recordset_metadata_format
-      )
+      recordset_list_body.must_match_schema(@recordset_list_format)
+      recordset_list_body['recordsets'].sample['zone_id'].must_equal(@zone_id)
+    end
+
+    it "#list_recordsets" do
+      recordset_list_body = @dns.list_recordsets(:zone_id => @zone_id).body
+      recordset_list_body.must_match_schema(@recordset_list_format)
       recordset_list_body['recordsets'].sample['zone_id'].must_equal(@zone_id)
     end
 


### PR DESCRIPTION
add header options for admin to query for all_projects or a specific other project

in https://github.com/sapcc/fog-openstack/blob/53b66cb021a6254ea9a69c13dd348d2b6ab0b8b0/lib/fog/dns/openstack/v2/requests/list_recordsets.rb#L7-L17 I would prefer to do the breaking change instead of that deprecation workaround - what do you think? we only offer this DNS API for 4 weeks - most likely it is not consumed, yet or the adaption still fresh to adjust for the change 😄 