### PR TITLE
Fix workflow service lookup

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -18,6 +18,7 @@ require 'fog/planning/openstack'
 require 'fog/storage/openstack'
 require 'fog/volume/openstack/v1'
 require 'fog/volume/openstack/v2'
+require 'fog/workflow/openstack/v2'
 
 module Fog
   module Compute


### PR DESCRIPTION
Adds missing require. In some usages, this error occurs:
uninitialized constant Fog::Workflow::OpenStack::V2