### PR TITLE
Fix MIME issues

### DIFF
--- a/lib/fog/storage/openstack.rb
+++ b/lib/fog/storage/openstack.rb
@@ -43,7 +43,22 @@ module Fog
       request :post_set_meta_temp_url_key
       request :public_url
 
+      module Utils
+        def require_mime_types
+          # Use mime/types/columnar if available, for reduced memory usage
+          require 'mime/types/columnar'
+          rescue LoadError
+            begin
+              require 'mime/types'
+            rescue LoadError
+              Fog::Logger.warning("'mime-types' missing, please install and try again.")
+              exit(1)
+            end
+          end
+      end
+
       class Mock
+        include Utils
         def self.data
           @data ||= Hash.new do |hash, key|
             hash[key] = {}
@@ -55,6 +70,7 @@ module Fog
         end
 
         def initialize(options = {})
+          require_mime_types
           @openstack_api_key = options[:openstack_api_key]
           @openstack_username = options[:openstack_username]
           @path = '/v1/AUTH_1234'
@@ -80,6 +96,7 @@ module Fog
       end
 
       class Real
+        include Utils
         include Fog::OpenStack::Core
 
         def self.not_found_class
@@ -87,6 +104,7 @@ module Fog
         end
 
         def initialize(options = {})
+          require_mime_types
           initialize_identity options
 
           @openstack_service_type           = options[:openstack_service_type] || ['object-store']


### PR DESCRIPTION
This adds the fixes found in
https://github.com/fog/fog-aws/commit/13bda13933711c7d3efa00bcf1e913e053aa34e6
that come up due to changing some gem dependencies around.

See https://github.com/fog/fog-core/issues/171 and
https://github.com/fog/fog-core/pull/170

Without this, trying to use "put_object" for storage results in:

```
NameError: uninitialized constant Fog::Storage::MIME
```
