### PR TITLE
[network] fix network mock

### DIFF
--- a/lib/fog/network/openstack.rb
+++ b/lib/fog/network/openstack.rb
@@ -203,17 +203,20 @@ module Fog
                   'router:external'       => false,
                   'admin_state_up'        => true,
                   'qos_policy_id'         => qos_policy_id,
-                  'port_security_enabled' => 'port_security_enabled'
+                  'port_security_enabled' => true
                 },
                 'e624a36d-762b-481f-9b50-4154ceb78bbb' => {
-                  'id'              => 'e624a36d-762b-481f-9b50-4154ceb78bbb',
-                  'name'            => 'network_1',
-                  'subnets'         => ['2e4ec6a4-0150-47f5-8523-e899ac03026e'],
-                  'shared'          => false,
-                  'status'          => 'ACTIVE',
-                  'admin_state_up'  => true,
-                  'tenant_id'       => 'f8b26a6032bc47718a7702233ac708b9',
-                  'router:external' => false,
+                  'id'                    => 'e624a36d-762b-481f-9b50-4154ceb78bbb',
+                  'name'                  => 'network_1',
+                  'subnets'               => ['2e4ec6a4-0150-47f5-8523-e899ac03026e'],
+                  'shared'                => false,
+                  'status'                => 'ACTIVE',
+                  'tenant_id'             => 'f8b26a6032bc47718a7702233ac708b9',
+                  'provider:network:type' => 'vlan',
+                  'router:external'       => false,
+                  'admin_state_up'        => true,
+                  'qos_policy_id'         => qos_policy_id,
+                  'port_security_enabled' => true
                 }
               },
               :ports                  => {},

--- a/lib/fog/network/openstack/requests/create_network.rb
+++ b/lib/fog/network/openstack/requests/create_network.rb
@@ -69,13 +69,13 @@ module Fog
           data = {
             'id'                    => Fog::Mock.random_numbers(6).to_s,
             'name'                  => options[:name],
-            'shared'                => options[:shared],
+            'shared'                => options[:shared] || false,
             'subnets'               => [],
             'status'                => 'ACTIVE',
-            'admin_state_up'        => options[:admin_state_up],
+            'admin_state_up'        => options[:admin_state_up] || false,
             'tenant_id'             => options[:tenant_id],
             'qos_policy_id'         => options[:qos_policy_id],
-            'port_security_enabled' => options[:port_security_enabled]
+            'port_security_enabled' => options[:port_security_enabled] || false
           }
           data.merge!(Fog::Network::OpenStack::Real.create(options))
           self.data[:networks][data['id']] = data


### PR DESCRIPTION
missing port_security_enabled and some boolean fallbacks in create network mock

moved out of https://github.com/fog/fog-openstack/pull/205

@gildub FYI