### PR TITLE
disable cop intended for ruby 3.0 migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,8 @@ SpaceBeforeFirstArg:
   Enabled: false
 SpecialGlobalVars:
   AutoCorrect: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
 StringLiterals:
   Enabled: false
 StringLiteralsInInterpolation:


### PR DESCRIPTION
I don't think it is planned to go for ruby 3.0 in the near future

moved out of #205

@gildub FYI