### PR TITLE
Stack update correction

### DIFF
--- a/lib/fog/orchestration/openstack/models/stack.rb
+++ b/lib/fog/orchestration/openstack/models/stack.rb
@@ -14,7 +14,11 @@ module Fog
 
         def save(options = {})
           if persisted?
-            service.update_stack(self, default_options.merge(options)).body['stack']
+            stack_default_options = default_options
+            if (options.key?(:template_url))
+              stack_default_options.delete(:template)
+            end
+            service.update_stack(self, stack_default_options.merge(options)).body['stack']
           else
             service.stacks.create(default_options.merge(options))
           end


### PR DESCRIPTION
Hi,

The stack update feature retrieves the current stack template and then merges user's template/ template url to it. However if the user is trying to update with a template url, it gets ignored since the template(self) is always present. 
This change is to consider user's template/template url if it's provided instead of the current stack's template. 
Could you please merge it? Thank you in advance. @Ladas @mdarby

Thanks
Deepali 