### PR TITLE
Remove redundant object_id attribute

### DIFF
--- a/lib/fog/network/openstack/models/rbac_policy.rb
+++ b/lib/fog/network/openstack/models/rbac_policy.rb
@@ -7,7 +7,6 @@ module Fog
         identity :id
 
         attribute :object_type
-        attribute :object_id
         attribute :tenant_id
         attribute :target_tenant
         attribute :action


### PR DESCRIPTION
This ain't necessary and generates a pesky warning:
"lib/fog/core/attributes/default.rb:53: \
warning: redefining `object_id' may cause serious problems"