### PR TITLE
Deprecation warning for Ruby 1.9.

### DIFF
--- a/lib/fog/openstack/version.rb
+++ b/lib/fog/openstack/version.rb
@@ -1,5 +1,11 @@
 module Fog
   module Openstack
     VERSION = "0.1.17"
+
+    def self.included(base)
+      if RUBY_VERSION < "2"
+        puts "DEPRECATION WARNING - Support for Ruby 1.9 will be dropped in fog-openstack 0.2 and higher. Please upgrade to Ruby 2 or above."
+      end
+    end
   end
 end


### PR DESCRIPTION
Need to do a release to 0.1.18 once this is merged.

Completes #228 