### PR TITLE
Handle NotFound in images v2 model's `get`

### DIFF
--- a/lib/fog/image/openstack/v2/models/images.rb
+++ b/lib/fog/image/openstack/v2/models/images.rb
@@ -18,6 +18,8 @@ module Fog
 
           def find_by_id(id)
             new(service.get_image_by_id(id).body)
+          rescue Fog::Image::OpenStack::NotFound
+            nil
           end
 
           alias get find_by_id

--- a/spec/fixtures/openstack/image_v2/images_v2_find_by_id.yml
+++ b/spec/fixtures/openstack/image_v2/images_v2_find_by_id.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:9292/v2/images/fe05659e-d433-4e09-aa78-19e0b7f5e497
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1e843e1adc5342dab74687f6b359185c
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Length:
+      - '563'
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Openstack-Request-Id:
+      - req-3ff0af92-827c-4e9d-bf1b-da27d93e4acb
+      Date:
+      - Thu, 25 Aug 2016 17:09:02 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"status": "queued", "name": "foobar", "tags": [], "container_format":
+        null, "created_at": "2016-08-25T17:09:00Z", "size": null, "disk_format": null,
+        "updated_at": "2016-08-25T17:09:00Z", "visibility": "private", "locations":
+        [], "self": "/v2/images/fe05659e-d433-4e09-aa78-19e0b7f5e497", "min_disk":
+        0, "protected": false, "id": "fe05659e-d433-4e09-aa78-19e0b7f5e497", "file":
+        "/v2/images/fe05659e-d433-4e09-aa78-19e0b7f5e497/file", "checksum": null,
+        "owner": "7b7688e5eecd4d6aa5b5b2cb3e93a778", "virtual_size": null, "min_ram":
+        0, "schema": "/v2/schemas/image"}'
+    http_version:
+  recorded_at: Thu, 25 Aug 2016 17:09:02 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:9292/v2/images/11111111-2222-3333-aaaa-bbbbbbcccce2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1e843e1adc5342dab74687f6b359185c
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      X-Openstack-Request-Id:
+      - req-28577b1e-64c3-463c-b9eb-540fb24ce017
+      Date:
+      - Fri, 26 Aug 2016 00:36:37 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: "404 Not Found\n\nNo image found with ID 11111111-2222-3333-aaaa-bbbbbbcccce2\n\n
+        \  "
+    http_version:
+  recorded_at: Fri, 26 Aug 2016 00:36:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/image_v1_spec.rb
+++ b/spec/image_v1_spec.rb
@@ -15,4 +15,19 @@ describe Fog::Image::OpenStack do
       @images = @service.images.all
     end
   end
+
+  describe 'find_by_id' do
+    it 'finds image' do
+      existing_image_id = 'ea20c966-d2fb-4287-a2eb-7bece9af4263'
+      VCR.use_cassette('list_images') do
+        @service.images.find_by_id(existing_image_id).id.must_equal existing_image_id
+      end
+    end
+
+    it 'returns nil when image is not found' do
+      VCR.use_cassette('list_images') do
+        assert_nil @service.images.find_by_id('non-existing-id')
+      end
+    end
+  end
 end

--- a/spec/image_v2_spec.rb
+++ b/spec/image_v2_spec.rb
@@ -332,4 +332,19 @@ describe Fog::Image::OpenStack do
       skip 'Creates, lists & gets tasks: to be implemented'
     end
   end
+
+  describe 'find_by_id' do
+    it 'finds image' do
+      existing_image_id = 'fe05659e-d433-4e09-aa78-19e0b7f5e497'
+      VCR.use_cassette('images_v2_find_by_id') do
+        @service.images.find_by_id(existing_image_id).id.must_equal existing_image_id
+      end
+    end
+
+    it 'returns nil when image is not found' do
+      VCR.use_cassette('images_v2_find_by_id') do
+        assert_nil @service.images.find_by_id('11111111-2222-3333-aaaa-bbbbbbcccce2')
+      end
+    end
+  end
 end

--- a/spec/image_v2_spec.rb
+++ b/spec/image_v2_spec.rb
@@ -21,7 +21,7 @@ describe Fog::Image::OpenStack do
       @service.images.all(:name => image_name).each(&:destroy)
     end
     # Check that the deletion worked
-    proc { @service.images.find_by_id image_id }.must_raise Fog::Image::OpenStack::NotFound if image_id
+    proc { @service.images.find_by_id(image_id).must_equal nil } if image_id
     @service.images.all(:name => image_name).length.must_equal 0 if image_name
   end
 


### PR DESCRIPTION
This is consistent with the behavior of `get` in other
 models, e.g. servers, volumes.

Signed-off-by: Beyhan Veli <beyhan.veli@sap.com>