### PR TITLE
removed extraneous tenant_id from quota_set in update_quota

### DIFF
--- a/lib/fog/compute/openstack/requests/update_quota.rb
+++ b/lib/fog/compute/openstack/requests/update_quota.rb
@@ -3,7 +3,6 @@ module Fog
     class OpenStack
       class Real
         def update_quota(tenant_id, options = {})
-          options['tenant_id'] = tenant_id
           request(
             :body    => Fog::JSON.encode('quota_set' => options),
             :expects => 200,

--- a/lib/fog/volume/openstack/requests/update_quota.rb
+++ b/lib/fog/volume/openstack/requests/update_quota.rb
@@ -3,7 +3,6 @@ module Fog
     class OpenStack
       module Real
         def update_quota(tenant_id, options = {})
-          options['tenant_id'] = tenant_id
           request(
             :body    => Fog::JSON.encode('quota_set' => options),
             :expects => 200,


### PR DESCRIPTION
In both the Compute and Volume update_quota actions, update_quota
was adding tenant_id to the quota_set hash. It doesn't belong there.
tenant_id is already in the URL and it doesn't go into the quota
hash. For the Compute operation, adding it to quota_set causes it
to fail. For Volume, it doesn't fail, but it still doesn't belong there.