### PR TITLE
pin down nokogiri gem for ruby 1.9

### DIFF
--- a/gemfiles/Gemfile-1.9
+++ b/gemfiles/Gemfile-1.9
@@ -7,6 +7,7 @@ group :development, :test do
   gem "ipaddress",       ">= 0.8"
   gem "bundler",         "~> 1.6"
   gem "mime-types",      "2.6.2"
+  gem "nokogiri",        "< 1.7.0"
   gem "rake",            "~> 10.0"
   gem "rubocop",         "< 0.42"
   gem "rubyzip",         "~> 0.9.9"


### PR DESCRIPTION
fix failing test for ruby 1.9: nokogiri 1.7.0 was released yesterday and dropped ruby < 2 support (https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#backwards-incompatibilities)