### PR TITLE
[dns] add immutable zone attribute 'attributes'

### DIFF
--- a/lib/fog/dns/openstack/v2/requests/create_zone.rb
+++ b/lib/fog/dns/openstack/v2/requests/create_zone.rb
@@ -9,7 +9,7 @@ module Fog
               'email' => email
             }
 
-            vanilla_options = [:ttl, :description, :type, :masters]
+            vanilla_options = [:ttl, :description, :type, :masters, :attributes]
 
             vanilla_options.select { |o| options[o] }.each do |key|
               data[key] = options[key]


### PR DESCRIPTION
attributes is a valid zone create parameter, see [designate source](https://github.com/openstack/designate/blob/master/designate/objects/adapters/api_v2/zone.py#L46) or [designate backend docu](http://docs.openstack.org/developer/designate/pools/scheduler.html#attribute-filter)