### PR TITLE
blank is not a standard ruby method, so replacing it with equivalent …

### DIFF
--- a/lib/fog/key_manager/openstack.rb
+++ b/lib/fog/key_manager/openstack.rb
@@ -89,7 +89,7 @@ module Fog
             end
           end
 
-          if version.blank?
+          if !version  || version.empty?
             raise Fog::OpenStack::Errors::ServiceUnavailable.new(
                     "OpenStack service only supports API versions #{supported_versions.inspect}")
           end


### PR DESCRIPTION
blank is not a standard ruby method, so replacing it with equivalent conditional statements