### PR TITLE
Add Panko Event service

### DIFF
--- a/examples/event/basics.rb
+++ b/examples/event/basics.rb
@@ -1,0 +1,22 @@
+require 'fog/openstack'
+require 'time'
+
+auth_url = "http://10.0.0.101:5000/v2.0/tokens"
+username = 'admin'
+password = 'D78JVyRnzJG8j7Mb6fgpeUMp7'
+
+@connection_params = {
+    :openstack_auth_url     => auth_url,
+    :openstack_username     => username,
+    :openstack_api_key      => password,
+}
+
+puts "### SERVICE CONNECTION ###"
+
+event_service = Fog::Event::OpenStack.new(@connection_params)
+
+p event_service
+
+puts "### LIST EVENTS ###"
+
+p event_service.events.all

--- a/lib/fog/event/openstack.rb
+++ b/lib/fog/event/openstack.rb
@@ -1,7 +1,5 @@
-
-
 module Fog
-  module Metering
+  module Event
     class OpenStack < Fog::Service
       SUPPORTED_VERSIONS = /v2/
 
@@ -17,25 +15,15 @@ module Fog
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
                  :openstack_identity_prefix
 
-      model_path 'fog/metering/openstack/models'
+      model_path 'fog/event/openstack/models'
 
-      model       :resource
-      collection  :resources
-
-      # Events extracted from Ceilometer (metering service) to Panko (event service) since Ocata release
       model       :event
       collection  :events
 
-      request_path 'fog/metering/openstack/requests'
+      request_path 'fog/event/openstack/requests'
 
-      # Metering
       request :get_event
-      request :get_resource
-      request :get_samples
-      request :get_statistics
       request :list_events
-      request :list_meters
-      request :list_resources
 
       class Mock
         def self.data
@@ -60,8 +48,8 @@ module Fog
           @auth_token_expiration = (Time.now.utc + 86400).iso8601
 
           management_url = URI.parse(options[:openstack_auth_url])
-          management_url.port = 8776
-          management_url.path = '/v1'
+          management_url.port = 8779
+          management_url.path = '/v2'
           @openstack_management_url = management_url.to_s
 
           @data ||= {:users => {}}
@@ -97,15 +85,15 @@ module Fog
         include Fog::OpenStack::Core
 
         def self.not_found_class
-          Fog::Metering::OpenStack::NotFound
+          Fog::Event::OpenStack::NotFound
         end
 
         def initialize(options = {})
           initialize_identity options
 
-          @openstack_service_type           = options[:openstack_service_type] || ['metering']
+          @openstack_service_type           = options[:openstack_service_type] || ['event']
           @openstack_service_name           = options[:openstack_service_name]
-          @openstack_endpoint_type          = options[:openstack_endpoint_type] || 'adminURL'
+          @openstack_endpoint_type          = options[:openstack_endpoint_type] || 'publicURL'
 
           @connection_options               = options[:connection_options] || {}
 

--- a/lib/fog/event/openstack/models/event.rb
+++ b/lib/fog/event/openstack/models/event.rb
@@ -1,0 +1,16 @@
+require 'fog/openstack/models/model'
+
+module Fog
+  module Event
+    class OpenStack
+      class Event < Fog::OpenStack::Model
+        identity :message_id
+
+        attribute :event_type
+        attribute :generated
+        attribute :raw
+        attribute :traits
+      end
+    end
+  end
+end

--- a/lib/fog/event/openstack/models/events.rb
+++ b/lib/fog/event/openstack/models/events.rb
@@ -1,0 +1,23 @@
+require 'fog/openstack/models/collection'
+require 'fog/event/openstack/models/event'
+
+module Fog
+  module Event
+    class OpenStack
+      class Events < Fog::OpenStack::Collection
+        model Fog::Event::OpenStack::Event
+
+        def all(q = [])
+          load_response(service.list_events(q))
+        end
+
+        def find_by_id(message_id)
+          event = service.get_event(message_id).body
+          new(event)
+        rescue Fog::Event::OpenStack::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/event/openstack/requests/get_event.rb
+++ b/lib/fog/event/openstack/requests/get_event.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Event
+    class OpenStack
+      class Real
+        def get_event(message_id)
+          request(
+            :expects => 200,
+            :method  => 'GET',
+            :path    => "events/#{message_id}"
+          )
+        end
+      end
+
+      class Mock
+        def get_event(_message_id)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'event_type' => 'compute.instance.create',
+            'message_id' => 'd646b40dea6347dfb8caee2da1484c56',
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/event/openstack/requests/list_events.rb
+++ b/lib/fog/event/openstack/requests/list_events.rb
@@ -1,0 +1,42 @@
+module Fog
+  module Event
+    class OpenStack
+      class Real
+        def list_events(options = [])
+          data = {
+            'q' => []
+          }
+
+          options.each do |opt|
+            filter = {}
+
+            ['field', 'op', 'value'].each do |key|
+              filter[key] = opt[key] if opt[key]
+            end
+
+            data['q'] << filter unless filter.empty?
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => 200,
+            :method  => 'GET',
+            :path    => 'events'
+          )
+        end
+      end
+
+      class Mock
+        def list_events(_options = {})
+          response = Excon::Response.new
+          response.status = 200
+          response.body = [{
+            'event_type' => 'compute.instance.create',
+            'message_id' => 'd646b40dea6347dfb8caee2da1484c56',
+          }]
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -29,6 +29,10 @@ module Fog
     end
   end
 
+  module Event
+    autoload :OpenStack, File.expand_path('../event/openstack', __FILE__)
+  end
+
   module Identity
     autoload :OpenStack, File.expand_path('../identity/openstack', __FILE__)
 

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -55,6 +55,10 @@ module Fog
     autoload :OpenStack, File.expand_path('../introspection/openstack', __FILE__)
   end
 
+  module KeyManager
+    autoload :OpenStack, File.expand_path('../key_manager/openstack', __FILE__)
+  end
+
   module Metering
     autoload :OpenStack, File.expand_path('../metering/openstack', __FILE__)
   end
@@ -104,32 +108,29 @@ module Fog
     end
   end
 
-  module KeyManager
-    autoload :OpenStack, File.expand_path('../key_manager/openstack', __FILE__)
-  end
-
   module OpenStack
     extend Fog::Provider
 
+    service(:baremetal,          'Baremetal')
     service(:compute,            'Compute')
-    service(:image,              'Image')
+    service(:container_infra,    'ContainerInfra')
+    service(:dns,                'DNS')
+    service(:event,              'Event')
     service(:identity,           'Identity')
-    service(:network,            'Network')
-    service(:storage,            'Storage')
-    service(:volume,             'Volume')
+    service(:image,              'Image')
+    service(:introspection,      'Introspection')
+    service(:key,                'KeyManager')
     service(:metering,           'Metering')
     service(:metric,             'Metric')
-    service(:orchestration,      'Orchestration')
-    service(:nfv,                'NFV')
-    service(:baremetal,          'Baremetal')
-    service(:planning,           'Planning')
-    service(:introspection,      'Introspection')
     service(:monitoring,         'Monitoring')
-    service(:workflow,           'Workflow')
-    service(:dns,                'DNS')
-    service(:key,                'KeyManager')
+    service(:network,            'Network')
+    service(:nfv,                'NFV')
+    service(:orchestration,      'Orchestration')
+    service(:planning,           'Planning')
     service(:shared_file_system, 'SharedFileSystem')
-    service(:container_infra,    'ContainerInfra')
+    service(:storage,            'Storage')
+    service(:volume,             'Volume')
+    service(:workflow,           'Workflow')
 
     @token_cache = {}
 

--- a/test/requests/event/event_tests.rb
+++ b/test/requests/event/event_tests.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+describe "Fog::Event[:openstack] | event requests" do
+  before do
+    @metering = Fog::Event::OpenStack.new
+    @event_format = {
+      'message_id' => String,
+      'event_type' => String
+    }
+  end
+
+  describe "success" do
+    it "#list_events" do
+      @metering.list_events.body.
+        must_match_schema([@event_format])
+    end
+
+    it "#get_event" do
+      @metering.get_event('test').body.
+        must_match_schema(@event_format)
+    end
+  end
+end


### PR DESCRIPTION
Events loading from Ceilometer service will be moved to separated service
called Panko from Ocata Openstack release. Panko has own entry in Openstack
endpoint list with an "Event" service type.

Adding support for this service extracting its code from Metering.

https://github.com/openstack/panko