### PR TITLE
Make caching for keystone V3 domains optional and configurable

### DIFF
--- a/lib/fog/identity/openstack/v3/models/domains.rb
+++ b/lib/fog/identity/openstack/v3/models/domains.rb
@@ -9,13 +9,19 @@ module Fog
           model Fog::Identity::OpenStack::V3::Domain
 
           def all(options = {})
-            cache = Fog::Identity::OpenStack::V3::Domain.cache
-            cached_domain, expires = cache[{:token => service.auth_token, :options => options}]
-            return cached_domain if cached_domain && expires > Time.now
-            domain_to_cache = load_response(service.list_domains(options), 'domains')
+            if service.openstack_cache_ttl > 0
+              cached_domain, expires = Fog::Identity::OpenStack::V3::Domain.cache[{:token   => service.auth_token,
+                                                                                   :options => options}]
+              return cached_domain if cached_domain && expires > Time.now
+            end
 
-            cache[{:token => service.auth_token, :options => options}] = domain_to_cache, Time.now + 30 # 30-second TTL
-            Fog::Identity::OpenStack::V3::Domain.cache = cache
+            domain_to_cache = load_response(service.list_domains(options), 'domains')
+            if service.openstack_cache_ttl > 0
+              cache = Fog::Identity::OpenStack::V3::Domain.cache
+              cache[{:token => service.auth_token, :options => options}] = [domain_to_cache,
+                                                                            Time.now + service.openstack_cache_ttl]
+              Fog::Identity::OpenStack::V3::Domain.cache = cache
+            end
             domain_to_cache
           end
 
@@ -28,15 +34,21 @@ module Fog
           end
 
           def find_by_id(id)
-            cache = Fog::Identity::OpenStack::V3::Domain.cache
-            cached_domain, expires = cache[{:token => service.auth_token, :id => id}]
-            return cached_domain if cached_domain && expires > Time.now
+            if service.openstack_cache_ttl > 0
+              cached_domain, expires = Fog::Identity::OpenStack::V3::Domain.cache[{:token => service.auth_token,
+                                                                                   :id    => id}]
+              return cached_domain if cached_domain && expires > Time.now
+            end
             domain_hash = service.get_domain(id).body['domain']
             domain_to_cache = Fog::Identity::OpenStack::V3::Domain.new(
               domain_hash.merge(:service => service)
             )
-            cache[{:token => service.auth_token, :id => id}] = domain_to_cache, Time.now + 30 # 30-second TTL
-            Fog::Identity::OpenStack::V3::Domain.cache = cache
+
+            if service.openstack_cache_ttl > 0
+              cache = Fog::Identity::OpenStack::V3::Domain.cache
+              cache[{:token => service.auth_token, :id => id}] = [domain_to_cache, Time.now + service.openstack_cache_ttl]
+              Fog::Identity::OpenStack::V3::Domain.cache = cache
+            end
             domain_to_cache
           end
 

--- a/spec/fixtures/openstack/identity_v3/idv3_domain.yml
+++ b/spec/fixtures/openstack/identity_v3/idv3_domain.yml
@@ -59,6 +59,63 @@ http_interactions:
   recorded_at: Tue, 03 May 2016 13:51:56 GMT
 - request:
     method: get
+    uri: http://devstack.openstack.stack:35357/v3/domains
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.38.0
+      Proxy-Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7f72291092a647578b115b853d129693
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Tue, 03 May 2016 13:51:55 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-1060d3e9-1be9-4e46-885a-3602551def93
+      Content-Length:
+      - '968'
+      Content-Type:
+      - application/json
+      X-Cache:
+      - MISS from i056593-u1404
+      X-Cache-Lookup:
+      - MISS from i056593-u1404:3128
+      Via:
+      - 1.1 i056593-u1404 (squid/3.3.8)
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"domains": [{"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/1617829d043b41858253a9a6e848615d"},
+        "enabled": true, "description": "Used for swift functional testing", "name":
+        "swift_test", "id": "1617829d043b41858253a9a6e848615d"}, {"links": {"self":
+        "http://devstack.openstack.stack:35357/v3/domains/36ba5b83865d482296b6d0682e983d77"},
+        "enabled": true, "description": "domain for services", "name": "monsooncc",
+        "id": "36ba5b83865d482296b6d0682e983d77"}, {"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/77e438db79474d5d90ab5f2c5c4942e2"},
+        "enabled": true, "description": "domain for user projects", "name": "monsoon2",
+        "id": "77e438db79474d5d90ab5f2c5c4942e2"}, {"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/default"},
+        "enabled": true, "description": "Owns users and tenants (i.e. projects) available
+        on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/domains", "previous": null, "next": null}}'
+    http_version:
+  recorded_at: Tue, 03 May 2016 13:51:56 GMT
+- request:
+    method: get
     uri: http://devstack.openstack.stack:35357/v3/domains/default
     body:
       encoding: US-ASCII


### PR DESCRIPTION
Applies a fix that was previously added to the
`Fog::Identity::OpenStack::V3::Projects` class in this commit:

https://github.com/fog/fog-openstack/pull/85/files#diff-598cf6b1198a78b938b1358eba6392e8

Fixes GH issue: #56