### PR TITLE
Extract custom properties when searching for images

### DIFF
--- a/lib/fog/image/openstack/v1/requests/get_image_by_id.rb
+++ b/lib/fog/image/openstack/v1/requests/get_image_by_id.rb
@@ -31,7 +31,8 @@ module Fog
               'X-Image-Meta-Protected'        => 'False',
               'X-Image-Meta-Size'             => 4979632,
               'X-Image-Meta-Status'           => 'deactivated',
-              'X-Image-Meta-Updated_at'       => '2016-02-25T03:02:05.000000'
+              'X-Image-Meta-Updated_at'       => '2016-02-25T03:02:05.000000',
+              'X-Image-Meta-Property-foo'     => 'bar'
             }
             response.body = {}
             response

--- a/spec/fixtures/openstack/image_v1/images_v1_find_by_id.yml
+++ b/spec/fixtures/openstack/image_v1/images_v1_find_by_id.yml
@@ -54,6 +54,8 @@ http_interactions:
       - '2016-02-25T03:02:05.000000'
       X-Openstack-Request-Id:
       - req-3ff0af92-827c-4e9d-bf1b-da27d93e4acb
+      X-Image-Meta-Property-foo:
+      - 'bar'
       Date:
       - Thu, 25 Aug 2016 17:09:02 GMT
       Connection:

--- a/spec/image_v1_spec.rb
+++ b/spec/image_v1_spec.rb
@@ -29,5 +29,13 @@ describe Fog::Image::OpenStack do
         assert_nil @service.images.find_by_id('non-existing-id')
       end
     end
+
+    it 'returns custom properties' do
+      existing_image_id = 'ea20c966-d2fb-4287-a2eb-7bece9af4263'
+      expected_value = 'bar'
+      VCR.use_cassette('images_v1_find_by_id') do
+        @service.images.find_by_id(existing_image_id).properties['foo'].must_equal expected_value
+      end
+    end
   end
 end


### PR DESCRIPTION
This patch fixes the logic when finding an image by ID, using the V1
version of Glance API. Response from Glance when getting details of
an image contains headers prefixed by one of two strings:

  - X-Image-Meta-
  - X-Image-Meta-Property

The second one is used for enumerating all the custom properties
associated with given image and the current version of the code wasn't
correctly handling them.

The source of the bug was that because `X-Image-Meta-` was used as the
prefix when selecting headers, all the custom properties were selected
as well - and then incorrectly treated like normal properties for that
image.