### PR TITLE
Handle nil values of data[:server_groups] in mock delete_server

### DIFF
--- a/lib/fog/compute/openstack/requests/delete_server.rb
+++ b/lib/fog/compute/openstack/requests/delete_server.rb
@@ -23,8 +23,11 @@ module Fog
               data[:last_modified][:servers].delete(server_id)
               data[:servers].delete(server_id)
               response.status = 204
-              group_id, = data[:server_groups].find { |_id, grp| grp[:members].include?(server_id) }
-              data[:server_groups][group_id][:members] -= [server_id] if group_id
+              server_groups = data[:server_groups]
+              if server_groups
+                group_id, = server_groups.find { |_id, grp| grp[:members].include?(server_id) }
+                server_groups[group_id][:members] -= [server_id] if group_id
+              end
             end
             response
           else


### PR DESCRIPTION
This patch modifies the logic in the mock implementation of deleting a server.
The original code has nil checks for making sure that we will only remove a
server from a group if that group exists - but it does not check whether the
whole collection of groups exist.

This can lead to a situation that if the user data when mocking doesn't contain
the key `data[:server_groups]`, we'd be hitting the nil pointer exception on the
calls to

  data[:server_groups].find

This only affects the mock implementation.