### PR TITLE
Handle numeric temp url keys

### DIFF
--- a/lib/fog/storage/openstack/requests/get_object_https_url.rb
+++ b/lib/fog/storage/openstack/requests/get_object_https_url.rb
@@ -53,7 +53,7 @@ module Fog
           object_path_unescaped = "#{@path}/#{Fog::OpenStack.escape(container)}/#{object}"
           string_to_sign = "#{method}\n#{expires}\n#{object_path_unescaped}"
 
-          hmac = Fog::HMAC.new('sha1', @openstack_temp_url_key)
+          hmac = Fog::HMAC.new('sha1', @openstack_temp_url_key.to_s)
           sig  = sig_to_hex(hmac.sign(string_to_sign))
 
           temp_url_options = {


### PR DESCRIPTION
As described in https://github.com/fog/fog-core/issues/210 numeric options are converted to integers in fog-core. This crashes when HMAC tries to sign, which requires the value to be a string. This change ensures, that is actually a string.

We are not sure how tests are currently setup in `fog-openstack`. There are some [temp url tests](https://github.com/fog/fog-openstack/blob/5049c7c750a1bf7d9d0d04ea2f389df56bfee19c/test/requests/storage/object_tests.rb) in the `test` folder, but were not able to get them running and could not find any documentation on how to setup them up.

Closes fog/fog-core#210

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>