### PR TITLE
Remove some dead code from mocks

### DIFF
--- a/lib/fog/compute/openstack/requests/create_server.rb
+++ b/lib/fog/compute/openstack/requests/create_server.rb
@@ -169,9 +169,6 @@ module Fog
             response_data['security_groups'] = groups
           end
 
-          data[:last_modified][:servers][server_id] = Time.now
-          data[:servers][server_id] = mock_data
-
           if options['os:scheduler_hints'] && options['os:scheduler_hints']['group']
             group = data[:server_groups][options['os:scheduler_hints']['group']]
             group[:members] << server_id if group


### PR DESCRIPTION
This patch removes two lines of unnecessary code - it looks like the exact same
calls are done two few lines above (lines 156 - 157).