### PR TITLE
Swift: support POST for objects.

### DIFF
--- a/lib/fog/storage/openstack.rb
+++ b/lib/fog/storage/openstack.rb
@@ -37,6 +37,7 @@ module Fog
       request :head_object
       request :put_container
       request :put_object
+      request :post_object
       request :put_object_manifest
       request :put_dynamic_obj_manifest
       request :put_static_obj_manifest

--- a/lib/fog/storage/openstack/requests/post_object.rb
+++ b/lib/fog/storage/openstack/requests/post_object.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Storage
+    class OpenStack
+      class Real
+        # Update object metadata
+        #
+        # ==== Parameters
+        # * container<~String> - Name for container, should be < 256 bytes and must not contain '/'
+        # * object<~String> - Name for object
+        # * headers<~Hash> - metadata headers for object. Defaults to {}.
+        #
+        def post_object(container, object, headers = {})
+
+          params = {
+            :expects    => 202,
+            :headers    => headers,
+            :method     => 'POST',
+            :path       => "#{Fog::OpenStack.escape(container)}/#{Fog::OpenStack.escape(object)}"
+          }
+
+          request(params)
+        end
+      end
+    end
+  end
+end

--- a/test/requests/storage/object_tests.rb
+++ b/test/requests/storage/object_tests.rb
@@ -79,6 +79,15 @@ describe "Fog::Storage[:openstack] | object requests" do
       Fog::Storage[:openstack].head_object('fogobjecttests', 'fog_object')
     end
 
+    it "#post_object('fogobjecttests', 'fog_object')" do
+      skip if Fog.mocking?
+      Fog::Storage[:openstack].post_object('fogobjecttests', 'fog_object',
+        'X-Object-Meta-test-header' => 'fog-test-value')
+      resp = Fog::Storage[:openstack].head_object('fogobjecttests', 'fog_object')
+      resp.headers.include?('X-Object-Meta-test-header')
+      resp.headers['X-Object-Meta-test-header'] == 'fog-test-value'
+    end
+
     it "#delete_object('fogobjecttests', 'fog_object')" do
       skip if Fog.mocking?
       Fog::Storage[:openstack].delete_object('fogobjecttests', 'fog_object')
@@ -184,6 +193,13 @@ describe "Fog::Storage[:openstack] | object requests" do
       skip if Fog.mocking?
       proc do
         Fog::Storage[:openstack].head_object('fognoncontainer', 'fog_non_object')
+      end.must_raise(Fog::Storage::OpenStack::NotFound)
+    end
+
+    it "#post_object('fognoncontainer', 'fog_non_object')" do
+      skip if Fog.mocking?
+      proc do
+        Fog::Storage[:openstack].post_object('fognoncontainer', 'fog_non_object')
       end.must_raise(Fog::Storage::OpenStack::NotFound)
     end
 


### PR DESCRIPTION
When an object is saved, fog should attempt to issue a POST, as
opposed to always reuploading the object. The patch adds a @dirty
instance variable to the File model to keep track of whether the
object needs to be PUT or if a POST should be issues. To support the
model, a post_object request is also added. The expected return code
is 202.

Fixes: #289