### PR TITLE
Allow more than 100 results post-Liberty.

### DIFF
--- a/lib/fog/metering/openstack/requests/get_samples.rb
+++ b/lib/fog/metering/openstack/requests/get_samples.rb
@@ -2,7 +2,7 @@ module Fog
   module Metering
     class OpenStack
       class Real
-        def get_samples(meter_id, options = [])
+        def get_samples(meter_id, options = [], limit = 10000000)
           data = {
             'q' => []
           }
@@ -15,6 +15,7 @@ module Fog
             end
 
             data['q'] << filter unless filter.empty?
+            data['limit'] = limit
           end
 
           request(


### PR DESCRIPTION
The Liberty release of Ceilometer introduced the idea of a limit variable to tell the API how many results you want. By default this is set to 100 in the server config. The onus is on the client to select how many results it wants.

I propose we default to a very high number as this will provide minimal disturbance to users.

Read this: https://specs.openstack.org/openstack/ceilometer-specs/specs/liberty/mandatory-limit.html

and this: https://docs.openstack.org/developer/ceilometer/webapi/v2.html#get--v2-meters-(meter_name)