### PR TITLE
Remove ".json" extension from Nova API requests

### DIFF
--- a/lib/fog/compute/openstack/requests/add_flavor_access.rb
+++ b/lib/fog/compute/openstack/requests/add_flavor_access.rb
@@ -9,7 +9,7 @@ module Fog
                                          }),
             :expects => [200, 203],
             :method  => 'POST',
-            :path    => "flavors/#{flavor_ref}/action.json"
+            :path    => "flavors/#{flavor_ref}/action"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/allocate_address.rb
+++ b/lib/fog/compute/openstack/requests/allocate_address.rb
@@ -7,7 +7,7 @@ module Fog
             :body    => Fog::JSON.encode('pool' => pool),
             :expects => [200, 202],
             :method  => 'POST',
-            :path    => 'os-floating-ips.json'
+            :path    => 'os-floating-ips'
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/boot_from_snapshot.rb
+++ b/lib/fog/compute/openstack/requests/boot_from_snapshot.rb
@@ -32,7 +32,7 @@ module Fog
             :body    => Fog::JSON.encode(data),
             :expects => [200, 202],
             :method  => 'POST',
-            :path    => '/os-volumes_boot.json'
+            :path    => '/os-volumes_boot'
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/create_key_pair.rb
+++ b/lib/fog/compute/openstack/requests/create_key_pair.rb
@@ -15,7 +15,7 @@ module Fog
             :body    => Fog::JSON.encode(data),
             :expects => 200,
             :method  => 'POST',
-            :path    => 'os-keypairs.json'
+            :path    => 'os-keypairs'
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/create_security_group.rb
+++ b/lib/fog/compute/openstack/requests/create_security_group.rb
@@ -14,7 +14,7 @@ module Fog
             :body    => Fog::JSON.encode(data),
             :expects => 200,
             :method  => 'POST',
-            :path    => 'os-security-groups.json'
+            :path    => 'os-security-groups'
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/create_security_group_rule.rb
+++ b/lib/fog/compute/openstack/requests/create_security_group_rule.rb
@@ -18,7 +18,7 @@ module Fog
             :expects => 200,
             :method  => 'POST',
             :body    => Fog::JSON.encode(data),
-            :path    => 'os-security-group-rules.json'
+            :path    => 'os-security-group-rules'
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/create_server.rb
+++ b/lib/fog/compute/openstack/requests/create_server.rb
@@ -77,7 +77,7 @@ module Fog
             end
           end
 
-          path = options['block_device_mapping'] ? 'os-volumes_boot.json' : 'servers.json'
+          path = options['block_device_mapping'] ? 'os-volumes_boot' : 'servers'
 
           request(
             :body    => Fog::JSON.encode(data),

--- a/lib/fog/compute/openstack/requests/get_flavor_details.rb
+++ b/lib/fog/compute/openstack/requests/get_flavor_details.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "flavors/#{flavor_ref}.json"
+            :path    => "flavors/#{flavor_ref}"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/get_host_details.rb
+++ b/lib/fog/compute/openstack/requests/get_host_details.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "os-hosts/#{host}.json"
+            :path    => "os-hosts/#{host}"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/get_image_details.rb
+++ b/lib/fog/compute/openstack/requests/get_image_details.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "images/#{image_id}.json"
+            :path    => "images/#{image_id}"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/get_server_details.rb
+++ b/lib/fog/compute/openstack/requests/get_server_details.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "servers/#{server_id}.json"
+            :path    => "servers/#{server_id}"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/get_server_password.rb
+++ b/lib/fog/compute/openstack/requests/get_server_password.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "servers/#{server_id}/os-server-password.json"
+            :path    => "servers/#{server_id}/os-server-password"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/list_addresses.rb
+++ b/lib/fog/compute/openstack/requests/list_addresses.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "servers/#{server_id}/ips.json"
+            :path    => "servers/#{server_id}/ips"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/list_all_addresses.rb
+++ b/lib/fog/compute/openstack/requests/list_all_addresses.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "os-floating-ips.json",
+            :path    => "os-floating-ips",
             :query   => options
           )
         end

--- a/lib/fog/compute/openstack/requests/list_flavors.rb
+++ b/lib/fog/compute/openstack/requests/list_flavors.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => 'flavors.json',
+            :path    => 'flavors',
             :query   => options
           )
         end

--- a/lib/fog/compute/openstack/requests/list_flavors_detail.rb
+++ b/lib/fog/compute/openstack/requests/list_flavors_detail.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => 'flavors/detail.json',
+            :path    => 'flavors/detail',
             :query   => options
           )
         end

--- a/lib/fog/compute/openstack/requests/list_hosts.rb
+++ b/lib/fog/compute/openstack/requests/list_hosts.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => 'os-hosts.json',
+            :path    => 'os-hosts',
             :query   => options
           )
         end

--- a/lib/fog/compute/openstack/requests/list_images.rb
+++ b/lib/fog/compute/openstack/requests/list_images.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => 'images.json'
+            :path    => 'images'
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/list_images_detail.rb
+++ b/lib/fog/compute/openstack/requests/list_images_detail.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => 'images/detail.json',
+            :path    => 'images/detail',
             :query   => filters
           )
         end

--- a/lib/fog/compute/openstack/requests/list_key_pairs.rb
+++ b/lib/fog/compute/openstack/requests/list_key_pairs.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => 'os-keypairs.json',
+            :path    => 'os-keypairs',
             :query   => options
           )
         end

--- a/lib/fog/compute/openstack/requests/list_metadata.rb
+++ b/lib/fog/compute/openstack/requests/list_metadata.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "/#{collection_name}/#{parent_id}/metadata.json"
+            :path    => "/#{collection_name}/#{parent_id}/metadata"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/list_private_addresses.rb
+++ b/lib/fog/compute/openstack/requests/list_private_addresses.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "servers/#{server_id}/ips/private.json"
+            :path    => "servers/#{server_id}/ips/private"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/list_public_addresses.rb
+++ b/lib/fog/compute/openstack/requests/list_public_addresses.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "servers/#{server_id}/ips/public.json"
+            :path    => "servers/#{server_id}/ips/public"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/list_security_groups.rb
+++ b/lib/fog/compute/openstack/requests/list_security_groups.rb
@@ -3,7 +3,7 @@ module Fog
     class OpenStack
       class Real
         def list_security_groups(options = {})
-          path = "os-security-groups.json"
+          path = "os-security-groups"
 
           if options.kind_of?(Hash)
             server_id = options.delete(:server_id)

--- a/lib/fog/compute/openstack/requests/list_servers.rb
+++ b/lib/fog/compute/openstack/requests/list_servers.rb
@@ -12,7 +12,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => 'servers.json',
+            :path    => 'servers',
             :query   => params
           )
         end

--- a/lib/fog/compute/openstack/requests/list_servers_detail.rb
+++ b/lib/fog/compute/openstack/requests/list_servers_detail.rb
@@ -13,7 +13,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => 'servers/detail.json',
+            :path    => 'servers/detail',
             :query   => params
           )
         end

--- a/lib/fog/compute/openstack/requests/list_tenants_with_flavor_access.rb
+++ b/lib/fog/compute/openstack/requests/list_tenants_with_flavor_access.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method  => 'GET',
-            :path    => "flavors/#{flavor_ref}/os-flavor-access.json"
+            :path    => "flavors/#{flavor_ref}/os-flavor-access"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/list_zones.rb
+++ b/lib/fog/compute/openstack/requests/list_zones.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => 200,
             :method  => 'GET',
-            :path    => 'os-availability-zone.json',
+            :path    => 'os-availability-zone',
             :query   => options
           )
         end

--- a/lib/fog/compute/openstack/requests/list_zones_detailed.rb
+++ b/lib/fog/compute/openstack/requests/list_zones_detailed.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => 200,
             :method  => 'GET',
-            :path    => 'os-availability-zone/detail.json',
+            :path    => 'os-availability-zone/detail',
             :query   => options
           )
         end

--- a/lib/fog/compute/openstack/requests/remove_flavor_access.rb
+++ b/lib/fog/compute/openstack/requests/remove_flavor_access.rb
@@ -9,7 +9,7 @@ module Fog
                                          }),
             :expects => [200, 203],
             :method  => 'POST',
-            :path    => "flavors/#{flavor_ref}/action.json"
+            :path    => "flavors/#{flavor_ref}/action"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/server_action.rb
+++ b/lib/fog/compute/openstack/requests/server_action.rb
@@ -7,7 +7,7 @@ module Fog
             :body    => Fog::JSON.encode(body),
             :expects => expects,
             :method  => 'POST',
-            :path    => "servers/#{server_id}/action.json"
+            :path    => "servers/#{server_id}/action"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/update_metadata.rb
+++ b/lib/fog/compute/openstack/requests/update_metadata.rb
@@ -7,7 +7,7 @@ module Fog
             :body    => Fog::JSON.encode('metadata' => metadata),
             :expects => 200,
             :method  => 'POST',
-            :path    => "#{collection_name}/#{parent_id}/metadata.json"
+            :path    => "#{collection_name}/#{parent_id}/metadata"
           )
         end
       end

--- a/lib/fog/compute/openstack/requests/update_server.rb
+++ b/lib/fog/compute/openstack/requests/update_server.rb
@@ -7,7 +7,7 @@ module Fog
             :body    => Fog::JSON.encode('server' => options),
             :expects => 200,
             :method  => 'PUT',
-            :path    => "servers/#{server_id}.json"
+            :path    => "servers/#{server_id}"
           )
         end
       end


### PR DESCRIPTION
The routes in the Nova API that support ".json" in the path are undocumented and are being removed as a consequence of refactoring the Nova API to remove stevedore.[1] As a consequence, certain Fog requests fail for new versions of Nova. This PR removes ".json" from requests to the Nova API.

I don't have an adequate way to fully test the consequences of this on every supported version of Nova.

@Ladas

[1] http://lists.openstack.org/pipermail/openstack-dev/2017-March/114736.html