### PR TITLE
Handle numeric temp url keys

### DIFF
--- a/lib/fog/storage/openstack/requests/get_object_https_url.rb
+++ b/lib/fog/storage/openstack/requests/get_object_https_url.rb
@@ -53,7 +53,7 @@ module Fog
           object_path_unescaped = "#{@path}/#{Fog::OpenStack.escape(container)}/#{object}"
           string_to_sign = "#{method}\n#{expires}\n#{object_path_unescaped}"
 
-          hmac = Fog::HMAC.new('sha1', @openstack_temp_url_key)
+          hmac = Fog::HMAC.new('sha1', @openstack_temp_url_key.to_s)
           sig  = sig_to_hex(hmac.sign(string_to_sign))
 
           temp_url_options = {

--- a/test/requests/storage/object_tests.rb
+++ b/test/requests/storage/object_tests.rb
@@ -106,6 +106,14 @@ describe "Fog::Storage[:openstack] | object requests" do
         url_s = Fog::Storage[:openstack].get_object_https_url(@directory.identity, 'fog_object', ts)
         test_temp_url(url_s, ts, 'https')
       end
+
+      it "#get_object_https_url_numeric('directory.identity', 'fog_object', expiration_timestamp)" do
+        skip if Fog.mocking?
+        ts = Time.at(1500000000)
+        fog = Fog::Storage.new(provider: :openstack, openstack_temp_url_key: '12345')
+        url_s = fog.get_object_https_url(@directory.identity, 'fog_object', ts)
+        test_temp_url(url_s, ts, 'https')
+      end
     end
 
     describe "put_object with block" do


### PR DESCRIPTION
As described in https://github.com/fog/fog-core/issues/210
there numeric options are converted to integers in fog-core.
This crashes when HMAC tries to sign, which requires the
value to be a string. This changes ensures, that is acutally
a string.

Added a unit test to validate the fix.

Closes fog/fog-core#210

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>