### PR TITLE
[WIP] Fix HTTP body params on GET queries

### DIFF
--- a/lib/fog/event/openstack/requests/list_events.rb
+++ b/lib/fog/event/openstack/requests/list_events.rb
@@ -18,7 +18,7 @@ module Fog
           end
 
           request(
-            :body    => Fog::JSON.encode(data),
+            :query   => data,
             :expects => 200,
             :method  => 'GET',
             :path    => 'events'

--- a/lib/fog/metering/openstack/requests/get_samples.rb
+++ b/lib/fog/metering/openstack/requests/get_samples.rb
@@ -19,7 +19,7 @@ module Fog
           end
 
           request(
-            :body    => Fog::JSON.encode(data),
+            :query   => data,
             :expects => 200,
             :method  => 'GET',
             :path    => "meters/#{meter_id}"

--- a/lib/fog/metering/openstack/requests/get_statistics.rb
+++ b/lib/fog/metering/openstack/requests/get_statistics.rb
@@ -19,7 +19,7 @@ module Fog
           end if options['q'].kind_of? Array
 
           request(
-            :body    => Fog::JSON.encode(data),
+            :query   => data,
             :expects => 200,
             :method  => 'GET',
             :path    => "meters/#{meter_id}/statistics"

--- a/lib/fog/metering/openstack/requests/list_events.rb
+++ b/lib/fog/metering/openstack/requests/list_events.rb
@@ -18,7 +18,7 @@ module Fog
           end
 
           request(
-            :body    => Fog::JSON.encode(data),
+            :query   => data,
             :expects => 200,
             :method  => 'GET',
             :path    => 'events'

--- a/lib/fog/metering/openstack/requests/list_meters.rb
+++ b/lib/fog/metering/openstack/requests/list_meters.rb
@@ -18,7 +18,7 @@ module Fog
           end
 
           request(
-            :body    => Fog::JSON.encode(data),
+            :query   => data,
             :expects => 200,
             :method  => 'GET',
             :path    => 'meters'


### PR DESCRIPTION
There are some queries which use HTTP GET method, but pass parameters
in request body. This approach is not correct and might raise errors on
smarter firewalls.

Updating code moving parameters from body to query for Metering and Event
services.