### PR TITLE
Reformat setup instructions for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,23 +540,12 @@ neutron.add_router_interface router.id, subnet.id
 ## Development
 
 ```
-# 1. Clone repository
-$ git clone https://github.com/fog/fog-openstack.git
-
-# 2. Make sure rake is installed
-$ gem install rake
-
-# 3. Install dependencies from project directory
-$ cd fog-openstack; bin/setup
-
-# 4. Run tests
-$ rake spec
-
-# 5. Run interactive prompt that allows you to experiment (optional)
-$ bin/console
-
-# 6. Install gem to your local machine (optional)
-$ bundle exec rake Install
+$ git clone https://github.com/fog/fog-openstack.git # Clone repository
+$ gem install rake   # Make sure rake is installed
+$ cd fog-openstack; bin/setup   # Install dependencies from project directory
+$ rake spec   # Run tests
+$ bin/console   # Run interactive prompt that allows you to experiment (optional)
+$ bundle exec rake Install   # Install gem to your local machine (optional)
 ```
 
 In order to release a new version, perform the following steps:

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ neutron.add_router_interface router.id, subnet.id
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, make sure rake is installed by running `gem install rake`. Afterwards, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ p compute.flavors
 #         disk=1,
 #         vcpus=1,
 #         ...
-#       >, 
+#       >,
 #                   <Fog::Compute::OpenStack::Flavor
 #         id="2",
 #         name="m1.small",
@@ -182,7 +182,7 @@ security_group = compute.security_groups.create name:  "Test SSH",
 #     description="Allow access to port 22",
 #     security_group_rules=    <Fog::Compute::OpenStack::SecurityGroupRules
 #       [
-              
+
 #       ]
 #     >,
 #     tenant_id="06a9a90c60074cdeae5f7fdd0048d9ac"
@@ -418,7 +418,7 @@ identity.projects
 #         description="Project 1",
 #         enabled=true,
 #         name="project_1",
-#       >, 
+#       >,
 #        ...
 #        ]
 
@@ -539,9 +539,32 @@ neutron.add_router_interface router.id, subnet.id
 
 ## Development
 
-After checking out the repo, make sure rake is installed by running `gem install rake`. Afterwards, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+```
+# 1. Clone repository
+$ git clone https://github.com/fog/fog-openstack.git
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+# 2. Make sure rake is installed
+$ gem install rake
+
+# 3. Install dependencies from project directory
+$ cd fog-openstack; bin/setup
+
+# 4. Run tests
+$ rake spec
+
+# 5. Run interactive prompt that allows you to experiment (optional)
+$ bin/console
+
+# 6. Install gem to your local machine (optional)
+$ bundle exec rake Install
+```
+
+In order to release a new version, perform the following steps:
+
+1. Update version number in `version.rb`.
+2. Run `bundle exec rake release`, which will create a git tag for the version.
+3. Push git commits and tags.
+4. Push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
@@ -551,4 +574,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/fog/fo
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ $ git clone https://github.com/fog/fog-openstack.git # Clone repository
 $ cd fog-openstack; bin/setup   # Install dependencies from project directory
 $ rake spec   # Run tests
 $ bin/console   # Run interactive prompt that allows you to experiment (optional)
-$ bundle exec rake Install   # Install gem to your local machine (optional)
+$ bundle exec rake install   # Install gem to your local machine (optional)
 ```
 
 In order to release a new version, perform the following steps:

--- a/README.md
+++ b/README.md
@@ -541,7 +541,6 @@ neutron.add_router_interface router.id, subnet.id
 
 ```
 $ git clone https://github.com/fog/fog-openstack.git # Clone repository
-$ gem install rake   # Make sure rake is installed
 $ cd fog-openstack; bin/setup   # Install dependencies from project directory
 $ rake spec   # Run tests
 $ bin/console   # Run interactive prompt that allows you to experiment (optional)


### PR DESCRIPTION
If the rake gem is missing when the dependency installation procedure is triggered by running `/bin/setup`, it exits with the following error:

```
Building native extensions.  This could take a while...
ERROR:  Error installing rainbow:
	ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.3.0/gems/rainbow-2.2.2/ext
/usr/bin/ruby2.3 mkrf_conf.rb

current directory: /var/lib/gems/2.3.0/gems/rainbow-2.2.2/ext
/usr/bin/ruby2.3 -rubygems /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/rake RUBYARCHDIR=/var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/rainbow-2.2.2 RUBYLIBDIR=/var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/rainbow-2.2.2
/usr/bin/ruby2.3: No such file or directory -- /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/rake (LoadError)
```
Fixing that error requires `$ gem install rake` to be launched on the command line. Then, installing dependencies works as expected:

```
Bundle complete! 11 Gemfile dependencies, 30 gems now installed.
```
I added a corresponding instruction to the _Development_ section to make sure the presence of rake is checked beforehand.