### PR TITLE
Ruby 2.2.0 has an old bundler version:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 sudo: false
+before_install:
+  - gem update bundler
 script:
   - bundle exec rake test
   - bundle exec rake spec


### PR DESCRIPTION
### I expect 

all gates to work

### Instead

Ruby 2.2.0 requires a bundler update to work.

### This PR

  updates bundler in .travis.yml to fix the gate

### Notes

  The update may or may not be welcome. In that case, the 2.2.0 gate should be in the `Allowed Failures` 