### PR TITLE
Exclude test methods from BlockLength check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,17 @@ LineLength:
 MethodLength:
   Max: 25
   Severity: refactor
+# Exclude test methods from BlockLength.
+Metrics/BlockLength:
+  ExcludedMethods:
+  - after
+  - before
+  - context
+  - describe
+  - it
+  - model_tests
+  - namespace
+  - draw  
 ParameterLists:
   Severity: refactor
 PerceivedComplexity:


### PR DESCRIPTION
### I expect

Test blocks to be longer that 25 lines, and generally longer than actual blocks.

### This PR

Excludes test methods from BlockLength check.