### PR TITLE
150 lines is a suitable class length.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AlignHash:
 BlockNesting:
   Severity: refactor
 ClassLength:
+  Max: 150
   Severity: refactor
 ClassCheck:
   EnforcedStyle: kind_of?


### PR DESCRIPTION
### What does this PR do

Set 150 as a reasonable max class length in .rubocop.yml (which is a nice pick for new code). Old code may need refactoring to achieve that goal.

Feedback welcome for the right pick. Running rubocop on the project we get: 
```
lib/fog/compute/openstack/models/server.rb:7:7: R: Class has too many lines. [309/100]
lib/fog/dns/openstack/v2.rb:78:9: R: Class has too many lines. [218/100]
lib/fog/compute/openstack.rb:5:5: R: Class has too many lines. [188/100]
lib/fog/image/openstack/v2/models/image.rb:7:9: R: Class has too many lines. [163/100]
lib/fog/network/openstack.rb:5:5: R: Class has too many lines. [187/100]
lib/fog/network/openstack.rb:264:7: R: Class has too many lines. [171/100]
lib/fog/baremetal/openstack.rb:86:7: R: Class has too many lines. [150/100]
lib/fog/compute/openstack.rb:248:7: R: Class has too many lines. [115/100]
lib/fog/identity/openstack/v3.rb:6:7: R: Class has too many lines. [125/100]
lib/fog/storage/openstack/models/file.rb:6:7: R: Class has too many lines. [132/100]
```

