### PR TITLE
Fixes: #335. Add ruby 3.4.1 and 3.2.1. Remove ruby 2.1.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ env:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.0
-    gemfile: Gemfile
-  - rvm: 2.1.1
-    gemfile: Gemfile
   - rvm: 2.2.0
     gemfile: Gemfile
   - rvm: 2.3.0
+    gemfile: Gemfile
+  - rvm: 2.3.1
+    gemfile: Gemfile
+  - rvm: 2.4.2
     gemfile: Gemfile
   - rvm: jruby-head
     gemfile: Gemfile


### PR DESCRIPTION
  ManageIQ and other projects .travis.yml are tested
  against ruby 3.4.x and 3.2.x. Moreover ruby 2.1
  support has ended.