### PR TITLE
Allow soft affinity server groups

### DIFF
--- a/lib/fog/compute/openstack/models/server_group.rb
+++ b/lib/fog/compute/openstack/models/server_group.rb
@@ -9,7 +9,7 @@ module Fog
         attribute :policies, :type => :array
         attribute :members
 
-        VALID_SERVER_GROUP_POLICIES = ['affinity', 'anti-affinity'].freeze
+        VALID_SERVER_GROUP_POLICIES = ['affinity', 'anti-affinity', 'soft-affinity', 'soft-anti-affinity'].freeze
 
         def self.validate_server_group_policy(policy)
           raise ArgumentError, "#{policy} is an invalid policy... must use one of #{VALID_SERVER_GROUP_POLICIES.join(', ')}" \

--- a/lib/fog/compute/openstack/requests/create_server_group.rb
+++ b/lib/fog/compute/openstack/requests/create_server_group.rb
@@ -11,6 +11,7 @@ module Fog
           }}
           request(
             :body    => Fog::JSON.encode(body),
+            :headers => { "OpenStack-API-Version" => "compute latest" },
             :expects => 200,
             :method  => 'POST',
             :path    => 'os-server-groups'

--- a/lib/fog/compute/openstack/requests/create_server_group.rb
+++ b/lib/fog/compute/openstack/requests/create_server_group.rb
@@ -11,7 +11,7 @@ module Fog
           }}
           request(
             :body    => Fog::JSON.encode(body),
-            :headers => { "OpenStack-API-Version" => "compute latest" },
+            :headers => {'OpenStack-API-Version' => 'compute latest'},
             :expects => 200,
             :method  => 'POST',
             :path    => 'os-server-groups'


### PR DESCRIPTION
OpenStack Mitaka adds support for soft affinity and anti affinty groups.
Using these with an older installation of OpenStack results in an 400
http error code.
Also using Compute version lesser than 2.15 results in the same 400
code.
