### PR TITLE
Introduce microversions to compute service

### DIFF
--- a/lib/fog/compute/openstack.rb
+++ b/lib/fog/compute/openstack.rb
@@ -1,7 +1,7 @@
 module Fog
   module Compute
     class OpenStack < Fog::Service
-      SUPPORTED_VERSIONS = /v2\.0|v2\.1/.freeze
+      SUPPORTED_VERSIONS = /v2\.0|v2\.1/
       SUPPORTED_MICROVERSION = '2.15'.freeze
 
       requires :openstack_auth_url

--- a/lib/fog/compute/openstack.rb
+++ b/lib/fog/compute/openstack.rb
@@ -1,8 +1,9 @@
-
-
 module Fog
   module Compute
     class OpenStack < Fog::Service
+      SUPPORTED_VERSIONS = /v2\.0|v2\.1/
+      SUPPORTED_MICROVERSION = '2.15'.freeze
+
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_type, :openstack_service_name,
@@ -380,6 +381,10 @@ module Fog
         end
 
         def initialize(options = {})
+          @supported_versions = SUPPORTED_VERSIONS
+          @supported_microversion = SUPPORTED_MICROVERSION
+          @microversion_key = 'X-OpenStack-Nova-API-Version'.freeze
+
           initialize_identity options
 
           @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
@@ -391,9 +396,9 @@ module Fog
 
           authenticate
 
-          unless @path =~ /1\.1|v2/
+          unless @path =~ /\/(v2|v2\.0|v2\.1)\//
             raise Fog::OpenStack::Errors::ServiceUnavailable,
-                  "OpenStack compute binding only supports version 2 (a.k.a. 1.1)"
+                  "OpenStack compute binding only supports version v2 and v2.1"
           end
 
           @persistent = options[:persistent] || false

--- a/lib/fog/compute/openstack.rb
+++ b/lib/fog/compute/openstack.rb
@@ -1,7 +1,7 @@
 module Fog
   module Compute
     class OpenStack < Fog::Service
-      SUPPORTED_VERSIONS = /v2\.0|v2\.1/
+      SUPPORTED_VERSIONS = /v2\.0|v2\.1/.freeze
       SUPPORTED_MICROVERSION = '2.15'.freeze
 
       requires :openstack_auth_url
@@ -383,7 +383,7 @@ module Fog
         def initialize(options = {})
           @supported_versions = SUPPORTED_VERSIONS
           @supported_microversion = SUPPORTED_MICROVERSION
-          @microversion_key = 'X-OpenStack-Nova-API-Version'.freeze
+          @microversion_key = 'X-OpenStack-Nova-API-Version'
 
           initialize_identity options
 

--- a/lib/fog/compute/openstack.rb
+++ b/lib/fog/compute/openstack.rb
@@ -396,7 +396,7 @@ module Fog
 
           authenticate
 
-          unless @path =~ /\/(v2|v2\.0|v2\.1)\//
+          unless @path =~ %r{/(v2|v2\.0|v2\.1)/}
             raise Fog::OpenStack::Errors::ServiceUnavailable,
                   "OpenStack compute binding only supports version v2 and v2.1"
           end

--- a/lib/fog/compute/openstack/models/server_group.rb
+++ b/lib/fog/compute/openstack/models/server_group.rb
@@ -9,7 +9,7 @@ module Fog
         attribute :policies, :type => :array
         attribute :members
 
-        VALID_SERVER_GROUP_POLICIES = ['affinity', 'anti-affinity'].freeze
+        VALID_SERVER_GROUP_POLICIES = ['affinity', 'anti-affinity', 'soft-affinity', 'soft-anti-affinity'].freeze
 
         def self.validate_server_group_policy(policy)
           raise ArgumentError, "#{policy} is an invalid policy... must use one of #{VALID_SERVER_GROUP_POLICIES.join(', ')}" \

--- a/test/models/compute/server_group_tests.rb
+++ b/test/models/compute/server_group_tests.rb
@@ -1,11 +1,9 @@
 require "test_helper"
 
 describe "Fog::Compute::OpenStack::ServerGroup" do
-
   describe "validate_server_group_policy" do
-
     it "contains only allowed policies" do
-      ['affinity', 'anti-affinity', 'soft-affinity', 'soft-anti-affinity'].each  do |policy|
+      ['affinity', 'anti-affinity', 'soft-affinity', 'soft-anti-affinity'].each do |policy|
         Fog::Compute::OpenStack::ServerGroup.validate_server_group_policy(policy).must_equal true
       end
     end

--- a/test/models/compute/server_group_tests.rb
+++ b/test/models/compute/server_group_tests.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+describe "Fog::Compute::OpenStack::ServerGroup" do
+
+  describe "validate_server_group_policy" do
+
+    it "contains only allowed policies" do
+      ['affinity', 'anti-affinity', 'soft-affinity', 'soft-anti-affinity'].each  do |policy|
+        Fog::Compute::OpenStack::ServerGroup.validate_server_group_policy(policy).must_equal true
+      end
+    end
+
+    it "raises an error" do
+      assert_raises ArgumentError do
+        Fog::Compute::OpenStack::ServerGroup.validate_server_group_policy('invalid-policy')
+      end
+    end
+  end
+end


### PR DESCRIPTION
OpenStack Mitaka adds support for soft (anti) affinity. For this the compute API mircoversion 2.15 is required. Older installation of OpenStack and older API microversions will result in a 400
http error code.

- We introduced Microversions to the compute service in order to support soft (anti) affinity.
- We added the soft affinity policies for server groups.
- We explicitly request either the v2 or v2.1 API endpoint version of the compute service.

Note: This PR is a follow up of https://github.com/fog/fog-openstack/pull/339 