### PR TITLE
[WIP] Remove rubyzip dependency

### DIFF
--- a/fog-openstack.gemspec
+++ b/fog-openstack.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mime-types-data"
   spec.add_development_dependency 'rake',    '~> 10.0'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'rubyzip', '~> 0.9.9'
   spec.add_development_dependency 'shindo',  '~> 0.3'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'vcr'


### PR DESCRIPTION
It seems zip is not used by fog-openstack, removing.