### PR TITLE
Allow compute URLs ending with service version

### DIFF
--- a/lib/fog/compute/openstack.rb
+++ b/lib/fog/compute/openstack.rb
@@ -396,7 +396,7 @@ module Fog
 
           authenticate
 
-          unless @path =~ %r{/(v2|v2\.0|v2\.1)/}
+          unless @path =~ %r{/(v2|v2\.0|v2\.1)}
             raise Fog::OpenStack::Errors::ServiceUnavailable,
                   "OpenStack compute binding only supports version v2 and v2.1"
           end


### PR DESCRIPTION
Some OpenStack systems provide URLs like
http://host:port/v2.1 for the compute service which didn't match.
This fix changes the version regex to match such URLs
  