### PR TITLE
Add the each_pair method to OpenStack::Metadata.

### DIFF
--- a/lib/fog/compute/openstack/models/metadata.rb
+++ b/lib/fog/compute/openstack/models/metadata.rb
@@ -31,6 +31,12 @@ module Fog
           nil
         end
 
+        def each_pair
+          requires :parent
+          data = service.list_metadata(collection_name, @parent.id).body['metadata']
+          data.each_pair { |k, v| yield(k, v) } unless data.nil?
+        end
+
         def update(data = nil)
           requires :parent
           service.update_metadata(collection_name, @parent.id, to_hash(data))


### PR DESCRIPTION
fog-core 2.0 includes an assumption that a model instance's metadata
is a dictionary and uses `each_pair` when merging the attributes. To
support fog-core 2.0, OpenStack::Metadata should include an
`each_pair` instance method.

Fixes #349