### PR TITLE
Do not upgrade to fog-core 2.0.

### DIFF
--- a/fog-openstack.gemspec
+++ b/fog-openstack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1.0'
 
-  spec.add_dependency 'fog-core',  '>= 1.40'
+  spec.add_dependency 'fog-core',  '~> 1.40'
   spec.add_dependency 'fog-json',  '>= 1.0'
   spec.add_dependency 'ipaddress', '>= 0.8'
 


### PR DESCRIPTION
Upgrading to fog-core 2.0 breaks the OpenStack::Metadata class and at
least two tests. Pin the dependency to be < 2.0 until those issues are
resolved.