### PR TITLE
Fixes #353: run tests in a travis-like docker container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+#
+# This file allows to:
+#   - create a ruby docker environment for development
+#   - run a testsuite from scratch like .travis.yml
+#
+# Run all tests with
+#
+# $ docker-compose up test
+#
+# Create the develompent environment with
+#
+# $ docker-compose up -d ruby
+# $ docker exec -ti fogopenstack_ruby_1  /bin/bash
+#
+version: '2'
+
+services:
+
+  ruby:
+    image: ruby
+    cap_add:
+    - SYS_PTRACE
+    volumes:
+    - .:/code:z
+    - .:/home/travis/build/fog/fog-openstack:z
+    entrypoint: tail -f /etc/hosts
+
+  test:
+    image: ruby
+    cap_add:
+    - SYS_PTRACE
+    volumes:
+    - .:/code:z
+    - .:/home/travis/build/fog/fog-openstack:z
+    environment:
+    - JRUBY_OPTS=--debug 
+    working_dir: /home/travis/build/fog/fog-openstack
+    entrypoint: |
+      bash -c '
+        gem update bundler --verbose
+        bundle install --verbose
+        bundle exec rake test
+        bundle exec rake spec
+        '


### PR DESCRIPTION
### what this PR do

  Provide a docker-compose.yml file enabling developing and
   testing in a brand new ruby container, thus mimicking
   travis behavior. Modifying the docker-compose enables
   testing on different ruby versions too.

### how to test it

Running should download the latest ruby image, install fog-openstack and its deps and run all tests.

```
$ docker-compose up test
```
  
### related issues

 #350 #353 