### PR TITLE
Skip tests that make assumptions about the FS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 before_install:
   - gem update bundler
 script:
-  - bundle exec rake test
+  - bundle exec rake test TESTOPTS="--verbose"
   - bundle exec rake spec
 env:
   - JRUBY_OPTS=--debug

--- a/lib/fog/orchestration/util/recursive_hot_file_loader.rb
+++ b/lib/fog/orchestration/util/recursive_hot_file_loader.rb
@@ -159,6 +159,7 @@ module Fog
           content = ''
           # open-uri doesn't open "file:///" uris.
           uri_or_filename = uri_or_filename.sub(/^file:/, "")
+
           open(uri_or_filename) { |f| content = f.read }
           content
         end

--- a/test/requests/orchestration/local_fullpath.yaml
+++ b/test/requests/orchestration/local_fullpath.yaml
@@ -6,6 +6,6 @@ resources:
   recurse_yaml_template:
     type: local.yaml
   add_yaml_file:
-    get_file: "local.yaml"
+    get_file: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/local.yaml"
   recurse_yaml_template_too:
-    type: "local.yaml"
+    type: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/local.yaml"

--- a/test/requests/orchestration/no_recursion.yaml
+++ b/test/requests/orchestration/no_recursion.yaml
@@ -6,6 +6,6 @@ resources:
   self_file:
     get_file: "no_recursion.yaml"
   yaml_file:
-    get_file: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/no_recursion.yaml"
+    get_file: "no_recursion.yaml"
   yaml_template:
-    type: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/no_recursion.yaml"
+    type: "no_recursion.yaml"

--- a/test/requests/orchestration/no_recursion.yaml
+++ b/test/requests/orchestration/no_recursion.yaml
@@ -6,6 +6,6 @@ resources:
   self_file:
     get_file: "no_recursion.yaml"
   yaml_file:
-    get_file: "no_recursion.yaml"
+    get_file: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/no_recursion.yaml"
   yaml_template:
-    type: "no_recursion.yaml"
+    type: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/no_recursion.yaml"

--- a/test/requests/orchestration/stack_files_util_tests.rb
+++ b/test/requests/orchestration/stack_files_util_tests.rb
@@ -2,6 +2,10 @@ require "test_helper"
 require "yaml"
 require "open-uri"
 
+def travis?
+  File.exist?('/home/travis/build/fog/fog-openstack')
+end
+
 describe "Fog::Orchestration[:openstack] | stack requests" do
   @create_format_files = {
     'id'    => String,
@@ -39,6 +43,7 @@ describe "Fog::Orchestration[:openstack] | stack requests" do
     end
 
     it "#get_file_contents_local_template" do
+      skip unless travis?
       # Heat files parameter is populated with URI-like syntax. The expected
       #  values are absolute paths uri and should be resolved with the local
       #  directory.
@@ -77,6 +82,7 @@ describe "Fog::Orchestration[:openstack] | stack requests" do
     end
 
     it "#recurse_template_and_file" do
+      skip unless travis?
       test_cases = @data["get_file_contents_local_template"].map do |testcase|
         [testcase['input'], testcase['expected']]
       end.compact


### PR DESCRIPTION
There is no reasonable way to run tests that use resources with a
hardcoded assumption about where the resource resides. Skip these
tests, unless the directory structure is setup for them to run
successfully (should be the case on Travis and in a docker container).