### PR TITLE
Change path logic when openstack identity prefix is 'v2.0'

### DIFF
--- a/lib/fog/identity/openstack.rb
+++ b/lib/fog/identity/openstack.rb
@@ -73,6 +73,8 @@ module Fog
             @path = "/#{options[:openstack_identity_prefix]}/#{@path}"
           end
 
+          @path = "/#{options[:openstack_identity_prefix]}/" if options[:openstack_identity_prefix] == "v2.0"
+
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
         end


### PR DESCRIPTION
There is an issue on RHOS 11 with identity service and keystone v2, when creating a tenant. Problem is that, path built by fog looks like this `/v2.0//v3`, when needed path is `/v2.0/`. I believe this PR can fix it.
I would like to mention this PR https://github.com/fog/fog-openstack/pull/99

P.S. In my case identity prefix comes from MiQ [link](https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb#L201)

ping @aufi