### PR TITLE
Broken Orchestration tests: Use relative path

### DIFF
--- a/lib/fog/orchestration/util/recursive_hot_file_loader.rb
+++ b/lib/fog/orchestration/util/recursive_hot_file_loader.rb
@@ -159,7 +159,6 @@ module Fog
           content = ''
           # open-uri doesn't open "file:///" uris.
           uri_or_filename = uri_or_filename.sub(/^file:/, "")
-
           open(uri_or_filename) { |f| content = f.read }
           content
         end

--- a/test/requests/orchestration/local_fullpath.yaml
+++ b/test/requests/orchestration/local_fullpath.yaml
@@ -6,6 +6,6 @@ resources:
   recurse_yaml_template:
     type: local.yaml
   add_yaml_file:
-    get_file: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/local.yaml"
+    get_file: "local.yaml"
   recurse_yaml_template_too:
-    type: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/local.yaml"
+    type: "local.yaml"

--- a/test/requests/orchestration/no_recursion.yaml
+++ b/test/requests/orchestration/no_recursion.yaml
@@ -6,6 +6,6 @@ resources:
   self_file:
     get_file: "no_recursion.yaml"
   yaml_file:
-    get_file: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/no_recursion.yaml"
+    get_file: "no_recursion.yaml"
   yaml_template:
-    type: "file:///home/travis/build/fog/fog-openstack/test/requests/orchestration/no_recursion.yaml"
+    type: "no_recursion.yaml"


### PR DESCRIPTION
Test are broken by the absolute path introduced since https://github.com/fog/fog-openstack/commit/2b32ce8b3d000b20d196601ddbda048d9a463554.

Initially the affected tests failure seemed to be local only but others forks are being impacted too. Therefore the urgent merge.