### PR TITLE
Fixes #353: run tests in a travis-like docker container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,9 +542,17 @@ neutron.add_router_interface router.id, subnet.id
 ```
 $ git clone https://github.com/fog/fog-openstack.git # Clone repository
 $ cd fog-openstack; bin/setup   # Install dependencies from project directory
-$ rake spec   # Run tests
+$ bundle exec rake test   # Run tests
+$ bundle exec rake spec   # Run tests
 $ bin/console   # Run interactive prompt that allows you to experiment (optional)
 $ bundle exec rake install   # Install gem to your local machine (optional)
+```
+
+You can also use a docker image for development and running tests. Once you have
+cloned the repository, it can be run with:
+```
+$ docker-compose up test
+$ docker-compose up ruby # Start a container with the ruby environment
 ```
 
 In order to release a new version, perform the following steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+#
+# This file allows to:
+#   - create a ruby docker environment for development
+#   - run a testsuite from scratch like .travis.yml
+#
+# Run all tests with
+#
+# $ docker-compose up test
+#
+# Create the develompent environment with
+#
+# $ docker-compose up -d ruby
+# $ docker exec -ti fogopenstack_ruby_1  /bin/bash
+#
+version: '2'
+
+services:
+
+  ruby:
+    image: ruby:2.4-stretch
+    cap_add:
+    - SYS_PTRACE
+    volumes:
+    - .:/code:z
+    - .:/home/travis/build/fog/fog-openstack:z
+    entrypoint: tail -f /etc/hosts
+
+  test:
+    image: ruby:2.4-stretch
+    cap_add:
+    - SYS_PTRACE
+    volumes:
+    - .:/code:z
+    - .:/home/travis/build/fog/fog-openstack:z
+    environment:
+    - JRUBY_OPTS=--debug 
+    working_dir: /home/travis/build/fog/fog-openstack
+    entrypoint: |
+      bash -c '
+        gem update bundler --verbose
+        bundle install --verbose
+        bundle exec rake test
+        bundle exec rake spec
+        '


### PR DESCRIPTION
  Provide a docker-compose.yml file enabling developing and
   testing in a brand new ruby container, thus mimicking
   travis behavior. Modifying the docker-compose enables
   testing on different ruby versions too.