### PR TITLE
Reverting Mock removal

### DIFF
--- a/lib/fog/identity/openstack.rb
+++ b/lib/fog/identity/openstack.rb
@@ -32,6 +32,15 @@ module Fog
         service
       end
 
+      class Mock
+        attr_reader :config
+
+        def initialize(options = {})
+          @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
+          @config = options
+        end
+      end
+
       class Real
         include Fog::OpenStack::Core
 

--- a/lib/fog/identity/openstack/v2.rb
+++ b/lib/fog/identity/openstack/v2.rb
@@ -66,6 +66,108 @@ module Fog
         request :get_ec2_credential
         request :list_ec2_credentials
 
+        class Mock
+          attr_reader :auth_token
+          attr_reader :auth_token_expiration
+          attr_reader :current_user
+          attr_reader :current_tenant
+          attr_reader :unscoped_token
+
+          def self.data
+            @users ||= {}
+            @roles ||= {}
+            @tenants ||= {}
+            @ec2_credentials ||= Hash.new { |hash, key| hash[key] = {} }
+            @user_tenant_membership ||= {}
+
+            @data ||= Hash.new do |hash, key|
+              hash[key] = {
+                :users                  => @users,
+                :roles                  => @roles,
+                :tenants                => @tenants,
+                :ec2_credentials        => @ec2_credentials,
+                :user_tenant_membership => @user_tenant_membership
+              }
+            end
+          end
+
+          def self.reset!
+            @data = nil
+            @users = nil
+            @roles = nil
+            @tenants = nil
+            @ec2_credentials = nil
+          end
+
+          def initialize(options = {})
+            @openstack_username = options[:openstack_username] || 'admin'
+            @openstack_tenant = options[:openstack_tenant] || 'admin'
+            @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
+            @openstack_management_url = @openstack_auth_uri.to_s
+
+            @auth_token = Fog::Mock.random_base64(64)
+            @auth_token_expiration = (Time.now.utc + 86400).iso8601
+
+            @admin_tenant = data[:tenants].values.find do |u|
+              u['name'] == 'admin'
+            end
+
+            if @openstack_tenant
+              @current_tenant = data[:tenants].values.find do |u|
+                u['name'] == @openstack_tenant
+              end
+
+              if @current_tenant
+                @current_tenant_id = @current_tenant['id']
+              else
+                @current_tenant_id = Fog::Mock.random_hex(32)
+                @current_tenant = data[:tenants][@current_tenant_id] = {
+                  'id'   => @current_tenant_id,
+                  'name' => @openstack_tenant
+                }
+              end
+            else
+              @current_tenant = @admin_tenant
+            end
+
+            @current_user = data[:users].values.find do |u|
+              u['name'] == @openstack_username
+            end
+            @current_tenant_id = Fog::Mock.random_hex(32)
+
+            if @current_user
+              @current_user_id = @current_user['id']
+            else
+              @current_user_id = Fog::Mock.random_hex(32)
+              @current_user = data[:users][@current_user_id] = {
+                'id'       => @current_user_id,
+                'name'     => @openstack_username,
+                'email'    => "#{@openstack_username}@mock.com",
+                'tenantId' => Fog::Mock.random_numbers(6).to_s,
+                'enabled'  => true
+              }
+            end
+          end
+
+          def data
+            self.class.data[@openstack_username]
+          end
+
+          def reset_data
+            self.class.data.delete(@openstack_username)
+          end
+
+          def credentials
+            {:provider                  => 'openstack',
+             :openstack_auth_url        => @openstack_auth_uri.to_s,
+             :openstack_auth_token      => @auth_token,
+             :openstack_management_url  => @openstack_management_url,
+             :openstack_current_user_id => @openstack_current_user_id,
+             :current_user              => @current_user,
+             :current_tenant            => @current_tenant}
+          end
+        end
+
         class Real < Fog::Identity::OpenStack::Real
           private
 

--- a/lib/fog/identity/openstack/v3.rb
+++ b/lib/fog/identity/openstack/v3.rb
@@ -116,6 +116,12 @@ module Fog
         request :update_policy
         request :delete_policy
 
+        class Mock
+          include Fog::OpenStack::Core
+          def initialize(options = {})
+          end
+        end
+
         def self.get_api_version(uri, connection_options = {})
           connection = Fog::Core::Connection.new(uri, false, connection_options)
           response = connection.request(:expects => [200],

--- a/lib/fog/network/openstack.rb
+++ b/lib/fog/network/openstack.rb
@@ -1,3 +1,5 @@
+
+
 module Fog
   module Network
     class OpenStack < Fog::Service
@@ -258,6 +260,187 @@ module Fog
       request :get_quota
       request :update_quota
       request :delete_quota
+
+      class Mock
+        def self.data
+          @data ||= Hash.new do |hash, key|
+            qos_policy_id = Fog::UUID.uuid
+            network_id   = Fog::UUID.uuid
+            extension_id = Fog::UUID.uuid
+            subnet_id    = Fog::UUID.uuid
+            tenant_id    = Fog::Mock.random_hex(8)
+
+            hash[key] = {
+              :extensions             => {
+                extension_id => {
+                  'id'          => extension_id,
+                  'alias'       => 'dvr',
+                  'description' => 'Enables configuration of Distributed Virtual Routers.',
+                  'links'       => [],
+                  'name'        => 'Distributed Virtual Router'
+                }
+              },
+              :networks               => {
+                network_id                => {
+                  'id'                    => network_id,
+                  'name'                  => 'Public',
+                  'subnets'               => [subnet_id],
+                  'shared'                => true,
+                  'status'                => 'ACTIVE',
+                  'tenant_id'             => tenant_id,
+                  'provider:network:type' => 'vlan',
+                  'router:external'       => false,
+                  'admin_state_up'        => true,
+                  'qos_policy_id'         => qos_policy_id,
+                  'port_security_enabled' => true
+                },
+                'e624a36d-762b-481f-9b50-4154ceb78bbb' => {
+                  'id'                    => 'e624a36d-762b-481f-9b50-4154ceb78bbb',
+                  'name'                  => 'network_1',
+                  'subnets'               => ['2e4ec6a4-0150-47f5-8523-e899ac03026e'],
+                  'shared'                => false,
+                  'status'                => 'ACTIVE',
+                  'tenant_id'             => 'f8b26a6032bc47718a7702233ac708b9',
+                  'provider:network:type' => 'vlan',
+                  'router:external'       => false,
+                  'admin_state_up'        => true,
+                  'qos_policy_id'         => qos_policy_id,
+                  'port_security_enabled' => true
+                }
+              },
+              :ports                  => {},
+              :subnets                => {
+                subnet_id => {
+                  'id'               => subnet_id,
+                  'name'             => "Public",
+                  'network_id'       => network_id,
+                  'cidr'             => "192.168.0.0/22",
+                  'ip_version'       => 4,
+                  'gateway_ip'       => Fog::Mock.random_ip,
+                  'allocation_pools' => [],
+                  'dns_nameservers'  => [Fog::Mock.random_ip, Fog::Mock.random_ip],
+                  'host_routes'      => [Fog::Mock.random_ip],
+                  'enable_dhcp'      => true,
+                  'tenant_id'        => tenant_id,
+                }
+              },
+              :subnet_pools           => {},
+              :floating_ips           => {},
+              :routers                => {},
+              :lb_pools               => {},
+              :lb_members             => {},
+              :lb_health_monitors     => {},
+              :lb_vips                => {},
+              :lbaas_loadbalancers    => {},
+              :lbaas_listeners        => {},
+              :lbaas_pools            => {},
+              :lbaas_pool_members     => {},
+              :lbaas_health_monitorss => {},
+              :lbaas_l7policies       => {},
+              :lbaas_l7rules          => {},
+              :vpn_services           => {},
+              :ike_policies           => {},
+              :ipsec_policies         => {},
+              :ipsec_site_connections => {},
+              :rbac_policies          => {},
+              :quota                  => {
+                "subnet"     => 10,
+                "router"     => 10,
+                "port"       => 50,
+                "network"    => 10,
+                "floatingip" => 50
+              },
+              :quotas                 => [
+                {
+                  "subnet"     => 10,
+                  "network"    => 10,
+                  "floatingip" => 50,
+                  "tenant_id"  => tenant_id,
+                  "router"     => 10,
+                  "port"       => 30
+                }
+              ],
+              :security_groups            => {},
+              :security_group_rules       => {},
+              :network_ip_availabilities  => [
+                {
+                  "network_id"              => "4cf895c9-c3d1-489e-b02e-59b5c8976809",
+                  "network_name"            => "public",
+                  "subnet_ip_availability"  => [
+                    {
+                      "cidr"          => "2001:db8::/64",
+                      "ip_version"    => 6,
+                      "subnet_id"     => "ca3f46c4-c6ff-4272-9be4-0466f84c6077",
+                      "subnet_name"   => "ipv6-public-subnet",
+                      "total_ips"     => 18446744073709552000,
+                      "used_ips"      => 1
+                    },
+                    {
+                      "cidr"          => "172.24.4.0/24",
+                      "ip_version"    => 4,
+                      "subnet_id"     => "cc02efc1-9d47-46bd-bab6-760919c836b5",
+                      "subnet_name"   => "public-subnet",
+                      "total_ips"     => 253,
+                      "used_ips"      => 1
+                    }
+                  ],
+                  "project_id"  => "1a02cc95f1734fcc9d3c753818f03002",
+                  "tenant_id"   => "1a02cc95f1734fcc9d3c753818f03002",
+                  "total_ips"   => 253,
+                  "used_ips"    => 2
+                },
+                {
+                  "network_id"              => "6801d9c8-20e6-4b27-945d-62499f00002e",
+                  "network_name"            => "private",
+                  "subnet_ip_availability"  => [
+                    {
+                      "cidr"        => "10.0.0.0/24",
+                      "ip_version"  => 4,
+                      "subnet_id"   => "44e70d00-80a2-4fb1-ab59-6190595ceb61",
+                      "subnet_name" => "private-subnet",
+                      "total_ips"   => 253,
+                      "used_ips"    => 2
+                    },
+                    {
+                      "ip_version"  => 6,
+                      "cidr"        => "fdbf:ac66:9be8::/64",
+                      "subnet_id"   => "a90623df-00e1-4902-a675-40674385d74c",
+                      "subnet_name" => "ipv6-private-subnet",
+                      "total_ips"   => 18446744073709552000,
+                      "used_ips"    => 2
+                    }
+                  ],
+                  "project_id"  => "d56d3b8dd6894a508cf41b96b522328c",
+                  "tenant_id"   => "d56d3b8dd6894a508cf41b96b522328c",
+                  "total_ips"   => 18446744073709552000,
+                  "used_ips"    => 4
+                }
+              ]
+            }
+          end
+        end
+
+        def self.reset
+          @data = nil
+        end
+
+        include Fog::OpenStack::Core
+
+        def initialize(options = {})
+          @auth_token = Fog::Mock.random_base64(64)
+          @auth_token_expiration = (Time.now.utc + 86400).iso8601
+
+          initialize_identity options
+        end
+
+        def data
+          self.class.data["#{@openstack_username}-#{@openstack_tenant}"]
+        end
+
+        def reset_data
+          self.class.data.delete("#{@openstack_username}-#{@openstack_tenant}")
+        end
+      end
 
       class Real
         include Fog::OpenStack::Core

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,12 +11,6 @@ require 'fog/test_helpers/minitest/expectations'
 
 require File.expand_path('../../lib/fog/openstack', __FILE__)
 
-# Load all service specific Mock classes
-require File.expand_path('../../test/lib/fog/identity/openstack', __FILE__)
-require File.expand_path('../../test/lib/fog/identity/openstack/v2', __FILE__)
-require File.expand_path('../../test/lib/fog/identity/openstack/v3', __FILE__)
-require File.expand_path('../../test/lib/fog/network/openstack', __FILE__)
-
 Fog.mock! if ENV["FOG_MOCK"] == "true"
 Bundler.require(:test)
 


### PR DESCRIPTION
Restores the built-in Mock feature which was killed by Mock classes being moved to `/test/lib/` in https://github.com/fog/fog-openstack/pull/223.

For this to eventually happen a broader work is necessary, this is being discussed [here](https://github.com/fog/fog-core/issues/198)