### PR TITLE
Fix error on empty body of File

### DIFF
--- a/lib/fog/storage/openstack/models/file.rb
+++ b/lib/fog/storage/openstack/models/file.rb
@@ -40,7 +40,7 @@ module Fog
 
         def body
           attributes[:body] ||= if last_modified
-                                  collection.get(identity).body
+                                  collection.get(identity).try(:body) || ''
                                 else
                                   ''
                                 end


### PR DESCRIPTION
Code at https://github.com/fog/fog-openstack/blob/master/lib/fog/storage/openstack/models/files.rb#L58-L59 can return nil, adapting _body_ method to not fail in this case.