### PR TITLE
Fix for https://github.com/theforeman/foreman/pull/5103

### DIFF
--- a/lib/fog/compute/openstack/models/server.rb
+++ b/lib/fog/compute/openstack/models/server.rb
@@ -227,12 +227,16 @@ module Fog
         end
 
         def security_groups
-          requires :id
+          if id
+            requires :id
 
-          groups = service.list_security_groups(:server_id => id).body['security_groups']
+            groups = service.list_security_groups(:server_id => id).body['security_groups']
 
-          groups.map do |group|
-            Fog::Compute::OpenStack::SecurityGroup.new group.merge(:service => service)
+            groups.map do |group|
+              Fog::Compute::OpenStack::SecurityGroup.new group.merge(:service => service)
+            end
+          else
+            service.security_groups.all()
           end
         end
 

--- a/lib/fog/compute/openstack/models/server.rb
+++ b/lib/fog/compute/openstack/models/server.rb
@@ -236,7 +236,7 @@ module Fog
               Fog::Compute::OpenStack::SecurityGroup.new group.merge(:service => service)
             end
           else
-            service.security_groups.all()
+            service.security_groups.all
           end
         end
 


### PR DESCRIPTION
for not created host id is not exists, but possibility to assign sec.groups should be.
this patch allow return all groups if host not created yet
https://github.com/theforeman/foreman/pull/5103 