### PR TITLE
Storage: Set cache-control header for a file

### DIFF
--- a/lib/fog/storage/openstack/models/file.rb
+++ b/lib/fog/storage/openstack/models/file.rb
@@ -7,6 +7,7 @@ module Fog
         identity  :key,             :aliases => 'name'
 
         attribute :access_control_allow_origin, :aliases => ['Access-Control-Allow-Origin']
+        attribute :cache_control,   :aliases => ['Cache-Control']
         attribute :content_length,  :aliases => ['bytes', 'Content-Length'], :type => :integer
         attribute :content_type,    :aliases => ['content_type', 'Content-Type']
         attribute :content_disposition, :aliases => ['content_disposition', 'Content-Disposition']
@@ -108,6 +109,7 @@ module Fog
 
         def save(options = {})
           requires :directory, :key
+          options['Cache-Control'] = cache_control if cache_control
           options['Content-Type'] = content_type if content_type
           options['Content-Disposition'] = content_disposition if content_disposition
           options['Access-Control-Allow-Origin'] = access_control_allow_origin if access_control_allow_origin

--- a/test/models/storage/file_tests.rb
+++ b/test/models/storage/file_tests.rb
@@ -74,6 +74,25 @@ unless Fog.mocking?
           end
         end
 
+        describe "#cache_control" do
+          before do
+            @instance = @directory.files.create(
+              :key           => 'meta-test',
+              :body          => lorem_file,
+              :cache_control => 'public, max-age=31536000'
+            )
+          end
+
+          after do
+            clear_metadata
+            @instance.save
+          end
+
+          it "sets Cache-Control on create" do
+            object_attributes(@instance)["Cache-Control"].must_equal "public, max-age=31536000"
+          end
+        end
+
         describe "#content_disposition" do
           before do
             @instance = @directory.files.create(


### PR DESCRIPTION
This PR adds ability to set cache-control header while uploading a file.