### PR TITLE
Moves autoload to allow reopening

### DIFF
--- a/lib/fog/dns/openstack.rb
+++ b/lib/fog/dns/openstack.rb
@@ -1,6 +1,9 @@
 module Fog
   module DNS
     class OpenStack < Fog::Service
+      autoload :V1, 'fog/dns/openstack/v1'
+      autoload :V2, 'fog/dns/openstack/v2'
+
       # Fog::DNS::OpenStack.new() will return a Fog::DNS::OpenStack::V2 or a Fog::DNS::OpenStack::V1,
       # choosing the latest available
       def self.new(args = {})

--- a/lib/fog/identity/openstack.rb
+++ b/lib/fog/identity/openstack.rb
@@ -3,6 +3,9 @@
 module Fog
   module Identity
     class OpenStack < Fog::Service
+      autoload :V2, 'fog/identity/openstack/v2'
+      autoload :V3, 'fog/identity/openstack/v3'
+
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,

--- a/lib/fog/image/openstack.rb
+++ b/lib/fog/image/openstack.rb
@@ -3,6 +3,9 @@
 module Fog
   module Image
     class OpenStack < Fog::Service
+      autoload :V1, 'fog/image/openstack/v1'
+      autoload :V2, 'fog/image/openstack/v2'
+
       # Fog::Image::OpenStack.new() will return a Fog::Image::OpenStack::V2 or a Fog::Image::OpenStack::V1,
       #  choosing the latest available
       def self.new(args = {})

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -1,11 +1,5 @@
-require 'fog/openstack/version'
 require 'fog/core'
 require 'fog/json'
-
-require 'fog/openstack/core'
-require 'fog/openstack/errors'
-
-require 'fog/planning/openstack'
 
 module Fog
   module Baremetal
@@ -22,11 +16,6 @@ module Fog
 
   module DNS
     autoload :OpenStack, 'fog/dns/openstack'
-
-    class OpenStack
-      autoload :V1, 'fog/dns/openstack/v1'
-      autoload :V2, 'fog/dns/openstack/v2'
-    end
   end
 
   module Event
@@ -35,20 +24,10 @@ module Fog
 
   module Identity
     autoload :OpenStack, 'fog/identity/openstack'
-
-    class OpenStack
-      autoload :V2, 'fog/identity/openstack/v2'
-      autoload :V3, 'fog/identity/openstack/v3'
-    end
   end
 
   module Image
     autoload :OpenStack, 'fog/image/openstack'
-
-    class OpenStack
-      autoload :V1, 'fog/image/openstack/v1'
-      autoload :V2, 'fog/image/openstack/v2'
-    end
   end
 
   module Introspection
@@ -94,11 +73,6 @@ module Fog
 
   module Volume
     autoload :OpenStack, 'fog/volume/openstack'
-
-    class OpenStack
-      autoload :V1, 'fog/volume/openstack/v1'
-      autoload :V2, 'fog/volume/openstack/v2'
-    end
   end
 
   module Workflow
@@ -110,6 +84,12 @@ module Fog
   end
 
   module OpenStack
+    autoload :VERSION, 'fog/openstack/version'
+
+    autoload :Core, 'fog/openstack/core'
+    autoload :Errors, 'fog/openstack/errors'
+    autoload :Planning, 'fog/planning/openstack'
+
     extend Fog::Provider
 
     service(:baremetal,          'Baremetal')

--- a/lib/fog/volume/openstack.rb
+++ b/lib/fog/volume/openstack.rb
@@ -3,6 +3,9 @@
 module Fog
   module Volume
     class OpenStack < Fog::Service
+      autoload :V1, 'fog/volume/openstack/v1'
+      autoload :V2, 'fog/volume/openstack/v2'
+
       @@recognizes = [:openstack_auth_token, :openstack_management_url,
                       :persistent, :openstack_service_type, :openstack_service_name,
                       :openstack_tenant, :openstack_tenant_id,


### PR DESCRIPTION
Per the idea of https://github.com/fog/fog-openstack/pull/386 this allows service class versions to be autoloaded so they can be reopened properly.

