### PR TITLE
Assign userid to keypairs

### DIFF
--- a/lib/fog/compute/openstack/models/key_pair.rb
+++ b/lib/fog/compute/openstack/models/key_pair.rb
@@ -25,9 +25,9 @@ module Fog
           requires :name
 
           data = if public_key
-                   service.create_key_pair(name, public_key).body['keypair']
+                   service.create_key_pair(name, public_key, user_id).body['keypair']
                  else
-                   service.create_key_pair(name).body['keypair']
+                   service.create_key_pair(name, nil, user_id).body['keypair']
                  end
           new_attributes = data.reject { |key, _value| !['fingerprint', 'public_key', 'name', 'private_key', 'user_id'].include?(key) }
           merge_attributes(new_attributes)

--- a/lib/fog/compute/openstack/requests/create_key_pair.rb
+++ b/lib/fog/compute/openstack/requests/create_key_pair.rb
@@ -2,7 +2,7 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def create_key_pair(key_name, public_key = nil)
+        def create_key_pair(key_name, public_key = nil, user_id = nil)
           data = {
             'keypair' => {
               'name' => key_name
@@ -10,6 +10,7 @@ module Fog
           }
 
           data['keypair']['public_key'] = public_key unless public_key.nil?
+          data['keypair']['user_id'] = user_id unless user_id.nil?
 
           request(
             :body    => Fog::JSON.encode(data),

--- a/lib/fog/compute/openstack/requests/delete_key_pair.rb
+++ b/lib/fog/compute/openstack/requests/delete_key_pair.rb
@@ -2,7 +2,9 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def delete_key_pair(key_name)
+        def delete_key_pair(key_name, user_id = nil)
+          options = {}
+          options[:user_id] = user_id unless user_id.nil?
           request(
             :expects => [202, 204],
             :method  => 'DELETE',


### PR DESCRIPTION
Added `user_id` to `create` and `delete` methods for keypairs in order to create/delete keypairs with assigned user ids to them. 
This needed for further fixes in https://bugzilla.redhat.com/show_bug.cgi?id=1589766