### PR TITLE
Compute: Add remote console

### DIFF
--- a/lib/fog/compute/openstack.rb
+++ b/lib/fog/compute/openstack.rb
@@ -116,6 +116,9 @@ module Fog
       request :migrate_server
       request :evacuate_server
 
+      # Server Remote Consoles
+      request :remote_consoles
+
       # Service CRUD
       request :list_services
       request :enable_service
@@ -338,7 +341,7 @@ module Fog
                   "port_state" => "ACTIVE"
                 }
               ]
-            }  
+            }
           end
         end
 

--- a/lib/fog/compute/openstack/requests/get_vnc_console.rb
+++ b/lib/fog/compute/openstack/requests/get_vnc_console.rb
@@ -3,6 +3,7 @@ module Fog
     class OpenStack
       class Real
         # Get a vnc console for an instance.
+        # For microversion < 2.6 as it has been replaced with remote-consoles
         #
         # === Parameters
         # * server_id <~String> - The ID of the server.
@@ -13,12 +14,20 @@ module Fog
         #     * url <~String>
         #     * type <~String>
         def get_vnc_console(server_id, console_type)
+          fixed_microversion = nil
+          if microversion_newer_than?('2.5')
+            fixed_microversion = @microversion
+            @microversion = '2.5'
+          end
+
           body = {
             'os-getVNCConsole' => {
               'type' => console_type
             }
           }
-          server_action(server_id, body)
+          result = server_action(server_id, body)
+          @microversion = fixed_microversion if fixed_microversion
+          result
         end
       end
 

--- a/lib/fog/compute/openstack/requests/remote_consoles.rb
+++ b/lib/fog/compute/openstack/requests/remote_consoles.rb
@@ -1,0 +1,54 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        # Get a vnc console for an instance.
+        # For microversion >= 2.6
+        #
+        # === Parameters
+        # * server_id <~String> - The ID of the server.
+        # * protocol <~String> - The protocol of remote console. The valid values are vnc, spice, rdp, serial and mks.
+        #   The protocol mks is added since Microversion 2.8.
+        # * type <~String> - The type of remote console. The valid values are novnc, xvpvnc, rdp-html5, spice-html5,
+        #   serial, and webmks. The type webmks is added since Microversion 2.8.
+        # === Returns
+        # * response <~Excon::Response>:
+        #   * body <~Hash>:
+        #     * url <~String>
+        #     * type <~String>
+        #     * protocol <~String>
+        def remote_consoles(server_id, protocol, type)
+          if microversion_newer_than?('2.6')
+            body = {
+              'remote_console' => {
+                'protocol' => protocol, 'type' => type
+              }
+            }
+
+            request(
+              :body    => Fog::JSON.encode(body),
+              :expects => 200,
+              :method  => 'POST',
+              :path    => "servers/#{server_id}/remote-consoles"
+            )
+          end
+        end
+      end
+
+      class Mock
+        def remote_consoles(_server_id, _protocol, _type)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            "remote_console" => {
+              "url"      => "http://192.168.27.100:6080/vnc_auto.html?token=e629bcbf-6f9e-4276-9ea1-d6eb0e618da5",
+              "type"     => "novnc",
+              "protocol" => "vnc"
+            }
+          }
+          response
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/fog/fog-openstack/issues/400

Also makes sure get_vnc_console runs only if microversion is < '2.5'

https://bugzilla.redhat.com/show_bug.cgi?id=1596320

When Nova is queried with Microversion < 2.6:
```bash
curl http://192.0.2.6:8774/v2.1/servers/f01dbe57-b811-423e-92a8-e1b77610129b/action -H "X-Auth-Token: $TOK" -H "Content-Type: application/json" -H "X-OpenStack-Nova-API-Version: 2.5" -X POST -d '{"os-getVNCConsole": {"type": "novnc"}}'
```

The request performs:
```bash     
{"console": {"url": "http://192.0.2.6:6080/vnc_auto.html?token=6a91cf7a-6fdc-44f0-80dc-19e0ff5131b9", "type": "novnc"}}
```

When using a Microversion > 2.5:
 ```bash
$ curl http://192.0.2.6:8774/v2.1/servers/f01dbe57-b811-423e-92a8-e1b77610129b/action -H "X-Auth-Token: $TOK" -H "Content-Type: application/json" -H "X-OpenStack-Nova-API-Version: 2.15" -X POST -d '{"os-getVNCConsole": {"type": "novnc"}}' 
```

The request fails:
```bash
{"itemNotFound": {"message": "The resource could not be found.", "code": 404}}
```
Anyway, the new approach is to use remote consoles:
```bash
curl http://192.0.2.6:8774/v2.1/servers/f01dbe57-b811-423e-92a8-e1b77610129b/remote-consoles -H "X-Auth-Token: $TOK" -H "Content-Type: application/json" -H "X-OpenStack-Nova-API-Version: 2.15" -X POST -d '{"remote_console": {"protocol": "vnc", "type": "novnc"}}' 
```

```bash
{"remote_console": {"url": "http://192.0.2.6:6080/vnc_auto.html?token=d12ee534-3b8f-47b5-bf23-1a7090f7d465", "type": "novnc", "protocol": "vnc"}}(
```

Tested against Nova version 2.53:
```ruby
irb > p @compute.get_vnc_console('f01dbe57-b811-423e-92a8-e1b77610129b', 'novnc').body
=> {"console"=>{"url"=>"http://192.0.2.6:6080/vnc_auto.html?token=a827264e-f978-49a4-977a-d7d7b15e489d", "type"=>"novnc"}}
```

```ruby
irb > p @compute.remote_consoles('f01dbe57-b811-423e-92a8-e1b77610129b', 'vnc', 'novnc').body
=> {"remote_console"=>{"url"=>"http://192.0.2.6:6080/vnc_auto.html?token=277b5dd0-9cac-4c92-989e-a2e8149fdcbd", "type"=>"novnc", "protocol"=>"vnc"}}
```
