### PR TITLE
Don't try to automatically set IDs for new flavors

### DIFF
--- a/lib/fog/compute/openstack/requests/create_flavor.rb
+++ b/lib/fog/compute/openstack/requests/create_flavor.rb
@@ -10,16 +10,6 @@ module Fog
         # swap        = Swap space in MB
         # rxtx_factor = RX/TX factor
         def create_flavor(attributes)
-          # Get last flavor id
-          flavor_ids = []
-          flavors = list_flavors_detail.body['flavors'] + list_flavors_detail(:is_public => false).body['flavors']
-          flavors.each do |flavor|
-            flavor_ids << flavor['id'].to_i
-          end
-
-          # Set flavor id
-          attributes[:flavor_id] = attributes[:flavor_id] || (!flavor_ids.empty? ? flavor_ids.sort.last + 1 : 1)
-
           data = {
             'flavor' => {
               'name'                       => attributes[:name],


### PR DESCRIPTION
The ID field is optional when creating new flavors in Openstack. If the field is left empty, Openstack will provide a UUID automatically. It's unnecessary for Fog to automatically try to guess the ID, and the ID-guessing code results in strange behavior if a flavor was created outside Fog with a non-integer ID.

https://bugzilla.redhat.com/show_bug.cgi?id=1608230