### PR TITLE
gitignore test/lorem.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gemfiles/Gemfile-1.9.lock
 .DS_Store
 .idea/
 vendor/bundle
+test/.lorem.txt


### PR DESCRIPTION
Ignores 'test/lorem.txt' file which is left behind when test are interrupted.