### PR TITLE
Add optional 'name' parameter to backup restore

### DIFF
--- a/lib/fog/volume/openstack/models/backup.rb
+++ b/lib/fog/volume/openstack/models/backup.rb
@@ -30,9 +30,9 @@ module Fog
           true
         end
 
-        def restore(volume_id)
+        def restore(volume_id = nil, name = nil)
           requires :id
-          service.restore_backup(id, volume_id)
+          service.restore_backup(id, volume_id, name)
           true
         end
 

--- a/lib/fog/volume/openstack/requests/restore_backup.rb
+++ b/lib/fog/volume/openstack/requests/restore_backup.rb
@@ -2,8 +2,8 @@ module Fog
   module Volume
     class OpenStack
       module Real
-        def restore_backup(backup_id, volume_id)
-          data = { 'restore' => { 'volume_id' => volume_id } }
+        def restore_backup(backup_id, volume_id = nil, name = nil)
+          data = { 'restore' => { 'volume_id' => volume_id, 'name' => name } }
           request(
             :expects  => 202,
             :method   => 'POST',


### PR DESCRIPTION
The Cinder API allows providing an optional "name" parameter that will be used when creating a volume to restore the backup to if a volume_id was not passed. This PR adds that parameter to the `restore_backup` request and `restore` method.