### PR TITLE
Network model: remove subnet attribute to support fog-core 2+

### DIFF
--- a/fog-openstack.gemspec
+++ b/fog-openstack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_dependency 'fog-core',  '~> 1.45.0'
+  spec.add_dependency 'fog-core',  '~> 2.1.2'
   spec.add_dependency 'fog-json',  '>= 1.0'
   spec.add_dependency 'ipaddress', '>= 0.8'
 

--- a/lib/fog/network/openstack/models/network.rb
+++ b/lib/fog/network/openstack/models/network.rb
@@ -7,7 +7,6 @@ module Fog
         identity :id
 
         attribute :name
-        attribute :subnets
         attribute :shared
         attribute :status
         attribute :admin_state_up


### PR DESCRIPTION
Image Rspec: Avoid using dynamic attribute