### PR TITLE
Fix create_temp_url due to missing @host variable

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -234,6 +234,7 @@ module Fog
         # both need to be set in service's initialize for microversions to work
         set_microversion if @supported_microversion && @supported_versions
         @path = api_path_prefix
+        @host = @openstack_management_uri.host
 
         true
       end


### PR DESCRIPTION
Class  `Fog::Storage::OpenStack::Mock` is setting `@host` variable, but `Real` version never do that. This breaks `Fog::Storage::OpenStack::Real.create_temp_url()` function, as it depends on `@host` variable.

This pull requests set correct @host variable.
