### PR TITLE
Storage: Use @openstack_management_uri only

### DIFF
--- a/lib/fog/storage/openstack.rb
+++ b/lib/fog/storage/openstack.rb
@@ -77,12 +77,8 @@ module Fog
           @openstack_management_url = options[:openstack_management_url] || 'http://example:8774/v2/AUTH_1234'
 
           @openstack_management_uri = URI.parse(@openstack_management_url)
-
-          @host   = @openstack_management_uri.host
           @path   = @openstack_management_uri.path
           @path.sub!(%r{/$}, '')
-          @port   = @openstack_management_uri.port
-          @scheme = @openstack_management_uri.scheme
         end
 
         def data

--- a/lib/fog/storage/openstack/requests/get_object_https_url.rb
+++ b/lib/fog/storage/openstack/requests/get_object_https_url.rb
@@ -38,9 +38,9 @@ module Fog
           raise ArgumentError, "Insufficient parameters specified." unless container && object && expires && method
           raise ArgumentError, "Storage must be instantiated with the :openstack_temp_url_key option" if @openstack_temp_url_key.nil?
 
-          scheme = options[:scheme] || @scheme
-          host = options[:host] || @host
-          port = options[:port] || @port
+          scheme = options[:scheme] || @openstack_management_uri.scheme
+          host = options[:host] || @openstack_management_uri.host
+          port = options[:port] || @openstack_management_uri.port
 
           # POST not allowed
           allowed_methods = %w(GET PUT HEAD)

--- a/lib/fog/storage/openstack/requests/public_url.rb
+++ b/lib/fog/storage/openstack/requests/public_url.rb
@@ -18,7 +18,8 @@ module Fog
         private
 
         def url
-          "#{@scheme}://#{@host}:#{@port}#{@path}"
+          "#{@openstack_management_uri.scheme}://#{@openstack_management_uri.host}:"\
+          "#{@openstack_management_uri.port}#{@path}"
         end
       end
 


### PR DESCRIPTION
Uses @openstack_management_uri for scheme, host and port which allow to avoid dedicated instance variables.
Adjusts Mock accordingly.
