### PR TITLE
Fix for OVH v2.0 auth with numeric tenant

### DIFF
--- a/lib/fog/openstack/auth/token/v2.rb
+++ b/lib/fog/openstack/auth/token/v2.rb
@@ -21,9 +21,9 @@ module Fog
             end
 
             if @tenant.id
-              identity['tenantId'] = @tenant.id
+              identity['tenantId'] = @tenant.id.to_s
             elsif @tenant.name
-              identity['tenantName'] = @tenant.name
+              identity['tenantName'] = @tenant.name.to_s
             else
               raise CredentialsError, "#{self.class}: No tenant available"
             end


### PR DESCRIPTION
OVH has numeric tenantName and expects it to be a string. Unfortunately fog converts any number string into number. This result in error when trying to autenticate:
```
Expected([200, 201]) <=> Actual(400 Bad Request)
excon.error.response
  :body          => "{\"error\": {\"message\": \"object of type 'int' has no len()\", \"code\": 400, \"title\": \"Bad Request\"}}"
  :cookies       => [
  ]
  :headers       => {
    "Content-Length"         => "96"
    "Content-Type"           => "application/json"
    "Vary"                   => "X-Auth-Token"
    "X-IPLB-Instance"        => "24498"
    "x-openstack-request-id" => "req-b8c0abe4-72e7-4811-b977-7700002c2990"
  }
  :host          => "auth.cloud.ovh.net"
  :local_address => "192.168.0.14"
  :local_port    => 44356
  :path          => "/v2.0/tokens"
  :port          => 443
  :reason_phrase => "Bad Request"
  :remote_ip     => "87.98.224.18"
  :status        => 400
  :status_line   => "HTTP/1.1 400 Bad Request\r\n"
```
first I tried to fix that at the root of problem (https://github.com/fog/fog-core/pull/243), but it looks like a dangerous place to change anything.