### PR TITLE
openstack_identity_api_version missing

### DIFF
--- a/lib/fog/baremetal/openstack.rb
+++ b/lib/fog/baremetal/openstack.rb
@@ -14,7 +14,8 @@ module Fog
                  :openstack_endpoint_type, :openstack_cache_ttl,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_api_version
 
       ## MODELS
       #

--- a/lib/fog/introspection/openstack.rb
+++ b/lib/fog/introspection/openstack.rb
@@ -14,7 +14,8 @@ module Fog
                  :openstack_endpoint_type, :openstack_cache_ttl,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_api_version
 
       ## REQUESTS
       #

--- a/lib/fog/nfv/openstack.rb
+++ b/lib/fog/nfv/openstack.rb
@@ -14,7 +14,8 @@ module Fog
                  :openstack_endpoint_type,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_api_version
 
       ## REQUESTS
       #


### PR DESCRIPTION
For baremetal, introspection and nvf
This is in the continuity of the new bootstrapping approach (v0.2+)