### PR TITLE
Fix for servers.com v2.0 auth

### DIFF
--- a/lib/fog/openstack/auth/token/v2.rb
+++ b/lib/fog/openstack/auth/token/v2.rb
@@ -37,7 +37,7 @@ module Fog
 
           def user_credentials
             {
-              'username' => @user.name,
+              'username' => @user.name.to_s,
               'password' => @user.password
             }
           end


### PR DESCRIPTION
servers.com OpenStack implementation expects `username` to be a string. Unfortunately fog converts any number string into number.