### PR TITLE
Identity v2: unscoped token fix

### DIFF
--- a/lib/fog/openstack/auth/token.rb
+++ b/lib/fog/openstack/auth/token.rb
@@ -14,7 +14,8 @@ module Fog
         class URLError < RuntimeError; end
 
         def self.build(auth)
-          if auth[:openstack_tenant_id] || auth[:openstack_tenant]
+          if auth[:openstack_identity_api_version] =~ /(v)*2(\.0)*/i ||
+             auth[:openstack_tenant_id] || auth[:openstack_tenant]
             Fog::OpenStack::Auth::Token::V2.new(auth)
           else
             Fog::OpenStack::Auth::Token::V3.new(auth)

--- a/lib/fog/openstack/auth/token/v2.rb
+++ b/lib/fog/openstack/auth/token/v2.rb
@@ -24,8 +24,6 @@ module Fog
               identity['tenantId'] = @tenant.id.to_s
             elsif @tenant.name
               identity['tenantName'] = @tenant.name.to_s
-            else
-              raise CredentialsError, "#{self.class}: No tenant available"
             end
 
             {'auth' => identity}


### PR DESCRIPTION
Allows for unscoped token under Keystone v2.0