### PR TITLE
Fog-core dependency: less than 2.1.1 along with monkey patch

### DIFF
--- a/fog-openstack.gemspec
+++ b/fog-openstack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_dependency 'fog-core',  '~> 2.1'
+  spec.add_dependency 'fog-core',  '>= 1.45', '<=2.1.0'
   spec.add_dependency 'fog-json',  '>= 1.0'
   spec.add_dependency 'ipaddress', '>= 0.8'
 


### PR DESCRIPTION
Fog-core 2.1.1 implies a entire namespace change which is available from fog-core 1.0.0.

So we want to make sure that fog-core version dependency is less than 2.1.0 but at same time we backport https://github.com/fog/fog-core/commit/06b7ab4 through a monkey patch to ensure not breaking behaviour if fog-core 2+ but less than 2.1.1 is used.