### PR TITLE
Image::V1: Service type is now imagev1

### DIFF
--- a/lib/fog/openstack/image/v1.rb
+++ b/lib/fog/openstack/image/v1.rb
@@ -111,7 +111,7 @@ module Fog
           end
 
           def default_service_type
-            %w[image]
+            %w[imagev1]
           end
         end
       end

--- a/lib/fog/openstack/image/v2.rb
+++ b/lib/fog/openstack/image/v2.rb
@@ -119,7 +119,7 @@ module Fog
           end
 
           def default_service_type
-            %w[image]
+            %w[image imagev2]
           end
         end
       end

--- a/spec/fixtures/openstack/image_v1/common_setup.yml
+++ b/spec/fixtures/openstack/image_v1/common_setup.yml
@@ -73,7 +73,7 @@ http_interactions:
         {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne",
         "interface": "public", "id": "b3b24c2c4ef44ff48049caff79149091"}, {"region_id":
         "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne", "interface":
-        "internal", "id": "b9d30173e66148baa3ab2dc2df33cb5e"}], "type": "image", "id":
+        "internal", "id": "b9d30173e66148baa3ab2dc2df33cb5e"}], "type": "imagev1", "id":
         "b936e5bfd38e4a3b97fcb8d08840881f", "name": "glance"}, {"endpoints": [{"region_id":
         "RegionOne", "url": "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface":
         "admin", "id": "1a6718d75cd94e24993a27d275442a17"}, {"region_id": "RegionOne",


### PR DESCRIPTION
Image service type v1 and v2 need to be differentiated.
Since openstack service type [1] doesn't offer an alias to distinguish between image v1 and v2 and because v1 is depreciate, let's keep the "image" service type to v2 and assign "imagev1" to v1.
While at it, let's also adds "imagev2" as a possible service type for v2.

https://github.com/fog/fog-openstack/issues/438

[1] https://git.openstack.org/cgit/openstack/service-types-authority/