### PR TITLE
Auth: Allows an auth_url path to contain version

### DIFF
--- a/lib/fog/openstack/auth/token.rb
+++ b/lib/fog/openstack/auth/token.rb
@@ -47,7 +47,7 @@ module Fog
             :headers => {'Content-Type' => 'application/json'},
             :body    => Fog::JSON.encode(creds[:data]),
             :method  => 'POST',
-            :path    => creds[:uri].path + path
+            :path    => creds[:uri].path + prefix_path(creds[:uri]) + path
           }
 
           connection.request(request)

--- a/lib/fog/openstack/auth/token/v2.rb
+++ b/lib/fog/openstack/auth/token/v2.rb
@@ -29,8 +29,16 @@ module Fog
             {'auth' => identity}
           end
 
+          def prefix_path(uri)
+            if uri.path =~ /\/v2(\.0)*(\/)*.*$/
+              ''
+            else
+              '/v2.0'
+            end
+          end
+
           def path
-            '/v2.0/tokens'
+            '/tokens'
           end
 
           def user_credentials

--- a/lib/fog/openstack/auth/token/v3.rb
+++ b/lib/fog/openstack/auth/token/v3.rb
@@ -37,8 +37,16 @@ module Fog
             end
           end
 
+          def prefix_path(uri)
+            if uri.path =~ /\/v3(\/)*.*$/
+              ''
+            else
+              '/v3'
+            end
+          end
+
           def path
-            '/v3/auth/tokens'
+            '/auth/tokens'
           end
 
           def scope


### PR DESCRIPTION
The prefix_path allows to ignore version  ('/v3' or 'v2.0') when the identity endpoint (`auth_url`)
 contains a version in its path.