### PR TITLE
Identity: Fix versionned endpoint

### DIFF
--- a/lib/fog/openstack/identity/identity.rb
+++ b/lib/fog/openstack/identity/identity.rb
@@ -5,26 +5,7 @@ module Fog
       autoload :V3, 'fog/openstack/identity/v3'
 
       def self.new(args = {})
-        version = if args[:openstack_identity_api_version] =~ /(v)*2(\.0)*/i
-                    '2.0'
-                  elsif args[:openstack_auth_url] =~ /v3|v2(\.0)*/
-                    # Deprecated from fog-openstack 0.2.0
-                    # Will be removed in future after hard deprecation is enforced for a couple of releases
-                    Fog::Logger.deprecation("An authentication URL including a version is deprecated")
-                    case args[:openstack_auth_url]
-                    when /\/v3(\/)*.*$/
-                      args[:openstack_auth_url].gsub!(/\/v3(\/)*.*$/, '')
-                      args[:no_path_prefix] = true
-                      '3'
-                    when /\/v2(\.0)*(\/)*.*$/
-                      args[:openstack_auth_url].gsub!(/\/v2(\.0)*(\/)*.*$/, '')
-                      args[:no_path_prefix] = true
-                      '2.0'
-                    end
-                  end
-
-        case version
-        when '2.0'
+        if args[:openstack_identity_api_version] =~ /(v)*2(\.0)*/i
           Fog::OpenStack::Identity::V2.new(args)
         else
           Fog::OpenStack::Identity::V3.new(args)

--- a/lib/fog/openstack/identity/v2.rb
+++ b/lib/fog/openstack/identity/v2.rb
@@ -169,12 +169,8 @@ module Fog
         end
 
         class Real < Fog::OpenStack::Identity::Real
-          def initialize(args)
-            @path_prefix = if args[:no_path_prefix]
-                             ''
-                           else
-                             'v2.0'
-                           end
+          def api_path_prefix
+            @path_prefix = version_in_path?(@openstack_management_uri.path) ? '' : 'v2.0'
             super
           end
 
@@ -184,6 +180,10 @@ module Fog
 
           def default_service_type
             %w[identity_v2 identityv2 identity]
+          end
+
+          def version_in_path?(url)
+            true if url =~ /\/v2(\.0)*(\/)*.*$/
           end
         end
       end

--- a/lib/fog/openstack/identity/v3.rb
+++ b/lib/fog/openstack/identity/v3.rb
@@ -13,7 +13,7 @@ module Fog
                    :openstack_user_domain_id, :openstack_project_domain_id,
                    :openstack_api_key, :openstack_current_user_id, :openstack_userid, :openstack_username,
                    :current_user, :current_user_id, :current_tenant,
-                   :provider, :openstack_identity_api_version, :openstack_cache_ttl, :no_path_prefix
+                   :provider, :openstack_identity_api_version, :openstack_cache_ttl
 
         model_path 'fog/openstack/identity/v3/models'
         model :domain
@@ -142,12 +142,8 @@ module Fog
         end
 
         class Real < Fog::OpenStack::Identity::Real
-          def initialize(args)
-            @path_prefix = if args[:no_path_prefix]
-                             ''
-                           else
-                             'v3'
-                           end
+          def api_path_prefix
+            @path_prefix = version_in_path?(@openstack_management_uri.path) ? '' : 'v3'
             super
           end
 
@@ -157,6 +153,10 @@ module Fog
 
           def default_service_type
             %w[identity_v3 identityv3 identity]
+          end
+
+          def version_in_path?(url)
+            true if url =~ /\/v3(\/)*.*$/
           end
         end
       end


### PR DESCRIPTION
The endpoint (from the catalog) must be used and not the auth_url must be used to check for a version in the path.
