### PR TITLE
Allow custom Content-Disposition filename in #create_temp_url method

### DIFF
--- a/lib/fog/openstack/storage/requests/get_object_https_url.rb
+++ b/lib/fog/openstack/storage/requests/get_object_https_url.rb
@@ -56,12 +56,14 @@ module Fog
           hmac = Fog::HMAC.new('sha1', @openstack_temp_url_key.to_s)
           sig  = sig_to_hex(hmac.sign(string_to_sign))
 
+          filename = options[:filename]
+
           temp_url_options = {
             :scheme => scheme,
             :host   => host,
             :port   => port,
             :path   => object_path_escaped,
-            :query  => "temp_url_sig=#{sig}&temp_url_expires=#{expires}"
+            :query  => "temp_url_sig=#{sig}&temp_url_expires=#{expires}&filename=#{filename}"
           }
           URI::Generic.build(temp_url_options).to_s
         end


### PR DESCRIPTION
Hi there,

To follow up on #338 I added the support for custom file names in Swift's temp url generation method `Fog::OpenStack::Storage::Real#create_temp_url`.

I found no tests for the `#create_temp_url` method so I did not write any. 

Note that the param is always passed, even when the `:filename` option isn't provided since the Swift service will simply use the last member of the path as the content disposition filename by default, even if the `filename=` param is passed an empty value.