### PR TITLE
storage: add openstack_storage_url option

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -16,6 +16,7 @@ module Fog
       attr_reader :openstack_project_id
       attr_reader :openstack_project_domain_id
       attr_reader :openstack_identity_api_version
+      attr_reader :openstack_storage_url
 
       # fallback
       def self.not_found_class
@@ -208,15 +209,7 @@ module Fog
 
           token = Fog::OpenStack::Auth::Token.build(openstack_options, @connection_options)
 
-          @openstack_management_url = if token.catalog
-                                        token.catalog.get_endpoint_url(
-                                          @openstack_service_type,
-                                          @openstack_endpoint_type,
-                                          @openstack_region
-                                        )
-                                      else
-                                        @openstack_auth_url
-                                      end
+          @openstack_management_url = management_url(token)
 
           @current_user = token.user['name']
           @current_user_id          = token.user['id']
@@ -236,6 +229,19 @@ module Fog
         @path = api_path_prefix
 
         true
+      end
+
+      protected
+      def management_url(token)
+        if token.catalog
+          token.catalog.get_endpoint_url(
+            @openstack_service_type,
+            @openstack_endpoint_type,
+            @openstack_region
+          )
+        else
+          @openstack_auth_url
+        end
       end
     end
   end

--- a/lib/fog/openstack/storage/storage.rb
+++ b/lib/fog/openstack/storage/storage.rb
@@ -1,5 +1,3 @@
-
-
 module Fog
   module OpenStack
     class Storage < Fog::Service
@@ -13,7 +11,7 @@ module Fog
                  :openstack_project_name, :openstack_project_id, :openstack_cache_ttl,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version, :openstack_temp_url_key
+                 :openstack_identity_api_version, :openstack_temp_url_key, :openstack_storage_url
 
       model_path 'fog/openstack/storage/models'
       model       :directory
@@ -55,7 +53,16 @@ module Fog
               Fog::Logger.warning("'mime-types' missing, please install and try again.")
               exit(1)
             end
-          end
+        end
+
+        def setup(options)
+          @openstack_storage_url = options[:openstack_storage_url]
+          super
+        end
+
+        def management_url(token)
+          @openstack_storage_url || super
+        end
       end
 
       class Mock


### PR DESCRIPTION
In order to support ACL management in my provider (OVH), I need to have users in a different tenant and I need to use another base URL for my storage calls. In the python client it is implemented using the OS_STORAGE_URL.

This is the equivalent option for fog.

I don't really know how to add tests to this, suggestions are highly welcomed

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>