### PR TITLE
Swift: Allow 202 for large objects creation/update/copy

### DIFF
--- a/lib/fog/openstack/storage/requests/copy_object.rb
+++ b/lib/fog/openstack/storage/requests/copy_object.rb
@@ -12,7 +12,7 @@ module Fog
         # * options<~Hash> - Additional headers
         def copy_object(source_container_name, source_object_name, target_container_name, target_object_name, options = {})
           headers = {'X-Copy-From' => "/#{source_container_name}/#{source_object_name}"}.merge(options)
-          request(:expects => 201,
+          request(:expects => [201, 202],
                   :headers => headers,
                   :method  => 'PUT',
                   :path    => "#{Fog::OpenStack.escape(target_container_name)}/#{Fog::OpenStack.escape(target_object_name)}")

--- a/lib/fog/openstack/storage/requests/put_object.rb
+++ b/lib/fog/openstack/storage/requests/put_object.rb
@@ -26,7 +26,7 @@ module Fog
           end
 
           params.merge!(
-            :expects    => 201,
+            :expects    => [201, 202],
             :idempotent => !params[:request_block],
             :headers    => headers,
             :method     => 'PUT',


### PR DESCRIPTION
Adds HTTP return code '202' (Accepted) for Container PUT and COPY requests.

OpenStack object storage API reference guide [1] implicitly mentions return code '202' is expected when dealing with large object for creation, update or copy [2]. 

[1] https://developer.openstack.org/api-ref/object-store/?expanded=copy-object-detail,create-or-replace-object-detail#create-or-update-object-metadata
[2] https://docs.openstack.org/swift/latest/api/large_objects.html

Thanks to @NickLaMuro for reporting this issue. 