### PR TITLE
Auto Retry (Idempotency requests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ If you're not sure whether your OpenStack cloud uses Keystone V2 or V3 then you 
 
 If you need a version of OpenStack to test against, get youself a copy of [DevStack](http://docs.openstack.org/developer/devstack/).
 
+### Auto Retry Requests
+
+Failed requests can be handled to allow retries capability.
+
+One use case is to be able to resubmit request when facing network latency.
+
+By default auto retry is deactivated.
+To activate auto retry set `idempotency` option to `true`
+
+The default values are:
+- retry limit is 2 times
+- retry interval is 5 seconds
+
+Those values can be overriden using `:retry_limit` and `:retry_interval` options.
+
 ### Networking Gotcha
 
 Note that tenants (aka projects) in OpenStack usually require that you create a default gateway router in order to allow external access to your instances.

--- a/lib/fog/openstack/baremetal.rb
+++ b/lib/fog/openstack/baremetal.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       ## MODELS
       #

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -14,7 +14,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       ## MODELS
       #

--- a/lib/fog/openstack/container_infra.rb
+++ b/lib/fog/openstack/container_infra.rb
@@ -14,7 +14,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       model_path 'fog/openstack/container_infra/models'
 

--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -48,6 +48,14 @@ module Fog
       private
 
       def request(params, parse_json = true)
+        if @idempotent && @idempotent_verbs.include?(params[:method])
+          params.merge!(
+            :idempotent     => @idempotent,
+            :retry_limit    => @retry_limit,
+            :retry_interval => @retry_interval
+          )
+        end
+
         retried = false
         begin
           authenticate! if @expires && (@expires - Time.now.utc).to_i < 60
@@ -171,6 +179,11 @@ module Fog
         options.select { |x| x.to_s.start_with? 'openstack' }.each do |openstack_param, value|
           instance_variable_set "@#{openstack_param}".to_sym, value
         end
+
+        @idempotent_verbs ||= %w(GET DELETE)
+        @idempotent     ||= !!options[:idempotent]
+        @retry_interval ||= options[:retry_interval] || 5 # Seconds
+        @retry_limit    ||= options[:retry_limit] || 2
 
         @auth_token ||= options[:openstack_auth_token]
         @openstack_must_reauthenticate = false

--- a/lib/fog/openstack/dns/v1.rb
+++ b/lib/fog/openstack/dns/v1.rb
@@ -14,7 +14,8 @@ module Fog
                    :openstack_project_name, :openstack_project_id,
                    :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                    :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                   :openstack_identity_api_version, :openstack_temp_url_key, :openstack_cache_ttl
+                   :openstack_identity_api_version, :openstack_temp_url_key, :openstack_cache_ttl,
+                   :idempotent, :retry_interval, :retry_limit
 
         request_path 'fog/openstack/dns/v1/requests'
 

--- a/lib/fog/openstack/dns/v2.rb
+++ b/lib/fog/openstack/dns/v2.rb
@@ -16,7 +16,8 @@ module Fog
                    :openstack_project_name, :openstack_project_id,
                    :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                    :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                   :openstack_identity_api_version, :openstack_temp_url_key, :openstack_cache_ttl
+                   :openstack_identity_api_version, :openstack_temp_url_key, :openstack_cache_ttl,
+                   :idempotent, :retry_interval, :retry_limit
 
         model_path 'fog/openstack/dns/v2/models'
         model       :zone

--- a/lib/fog/openstack/event.rb
+++ b/lib/fog/openstack/event.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       model_path 'fog/openstack/event/models'
 

--- a/lib/fog/openstack/identity/v2.rb
+++ b/lib/fog/openstack/identity/v2.rb
@@ -14,7 +14,8 @@ module Fog
                    :openstack_project_name, :openstack_project_id,
                    :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                    :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                   :openstack_identity_api_version, :no_path_prefix
+                   :openstack_identity_api_version, :no_path_prefix,
+                   :idempotent, :retry_interval, :retry_limit
 
         model_path 'fog/openstack/identity/v2/models'
         model :tenant

--- a/lib/fog/openstack/identity/v3.rb
+++ b/lib/fog/openstack/identity/v3.rb
@@ -13,7 +13,8 @@ module Fog
                    :openstack_user_domain_id, :openstack_project_domain_id,
                    :openstack_api_key, :openstack_current_user_id, :openstack_userid, :openstack_username,
                    :current_user, :current_user_id, :current_tenant,
-                   :provider, :openstack_identity_api_version, :openstack_cache_ttl
+                   :provider, :openstack_identity_api_version, :openstack_cache_ttl,
+                   :idempotent, :retry_interval, :retry_limit
 
         model_path 'fog/openstack/identity/v3/models'
         model :domain

--- a/lib/fog/openstack/image/v1.rb
+++ b/lib/fog/openstack/image/v1.rb
@@ -16,7 +16,8 @@ module Fog
                    :openstack_project_name, :openstack_project_id,
                    :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                    :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                   :openstack_identity_api_version
+                   :openstack_identity_api_version,
+                   :idempotent, :retry_interval, :retry_limit
 
         model_path 'fog/openstack/image/v1/models'
 

--- a/lib/fog/openstack/image/v2.rb
+++ b/lib/fog/openstack/image/v2.rb
@@ -16,7 +16,8 @@ module Fog
                    :openstack_project_name, :openstack_project_id,
                    :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                    :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                   :openstack_identity_api_version
+                   :openstack_identity_api_version,
+                   :idempotent, :retry_interval, :retry_limit
 
         model_path 'fog/openstack/image/v2/models'
 

--- a/lib/fog/openstack/introspection.rb
+++ b/lib/fog/openstack/introspection.rb
@@ -15,7 +15,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       ## REQUESTS
       #

--- a/lib/fog/openstack/key_manager.rb
+++ b/lib/fog/openstack/key_manager.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version, :openstack_temp_url_key, :openstack_cache_ttl
+                 :openstack_identity_api_version, :openstack_temp_url_key, :openstack_cache_ttl,
+                 :idempotent, :retry_interval, :retry_limit
 
 
       ## MODELS

--- a/lib/fog/openstack/metering.rb
+++ b/lib/fog/openstack/metering.rb
@@ -15,7 +15,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       model_path 'fog/openstack/metering/models'
 

--- a/lib/fog/openstack/metric.rb
+++ b/lib/fog/openstack/metric.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       model_path 'fog/openstack/metric/models'
 

--- a/lib/fog/openstack/monitoring.rb
+++ b/lib/fog/openstack/monitoring.rb
@@ -12,7 +12,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version, :openstack_temp_url_key, :openstack_cache_ttl
+                 :openstack_identity_api_version, :openstack_temp_url_key, :openstack_cache_ttl,
+                 :idempotent, :retry_interval, :retry_limit
 
       model_path 'fog/openstack/monitoring/models'
       model       :metric

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       ## MODELS
       #

--- a/lib/fog/openstack/nfv.rb
+++ b/lib/fog/openstack/nfv.rb
@@ -15,7 +15,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       ## REQUESTS
       #

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -11,7 +11,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       model_path 'fog/openstack/orchestration/models'
       model       :stack

--- a/lib/fog/openstack/planning.rb
+++ b/lib/fog/openstack/planning.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version,
+                 :idempotent, :retry_interval, :retry_limit
 
       ## MODELS
       #

--- a/lib/fog/openstack/shared_file_system.rb
+++ b/lib/fog/openstack/shared_file_system.rb
@@ -14,7 +14,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version, :openstack_shared_file_system_microversion
+                 :openstack_identity_api_version, :openstack_shared_file_system_microversion,
+                 :idempotent, :retry_interval, :retry_limit
 
       model_path 'fog/openstack/shared_file_system/models'
       model       :network

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id, :openstack_cache_ttl,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version, :openstack_temp_url_key
+                 :openstack_identity_api_version, :openstack_temp_url_key,
+                 :idempotent, :retry_interval, :retry_limit
 
       model_path 'fog/openstack/storage/models'
       model       :directory

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -15,7 +15,8 @@ module Fog
                       :openstack_project_name, :openstack_project_id,
                       :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                       :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                      :openstack_identity_api_version]
+                      :openstack_identity_api_version,
+                      :idempotent, :retry_interval, :retry_limit]
 
       # Fog::OpenStack::Image.new() will return a Fog::OpenStack::Volume::V2 or a Fog::OpenStack::Volume::V1,
       #  choosing the V2 by default, as V1 is deprecated since OpenStack Juno

--- a/lib/fog/openstack/workflow/v2.rb
+++ b/lib/fog/openstack/workflow/v2.rb
@@ -8,7 +8,8 @@ module Fog
 
         requires :openstack_auth_url
         recognizes :openstack_username, :openstack_api_key,
-                   :openstack_project_name, :openstack_domain_id
+                   :openstack_project_name, :openstack_domain_id,
+                   :idempotent, :retry_interval, :retry_limit
 
         ## REQUESTS
         #


### PR DESCRIPTION
Auto Retry option for all services

Auto Retry is off by default but can be turned on with `:idempotent` option.
Default values are `:retry_limit => 2` and `:retry_interval => 5` (seconds) 

Only GET and DELETE REST verbs are used for auto retry. More verbs can be added if that make sense.

Addresses https://github.com/fog/fog-openstack/issues/453