### PR TITLE
Add block_device_mapping attribute to image model

### DIFF
--- a/lib/fog/openstack/image/v2/models/image.rb
+++ b/lib/fog/openstack/image/v2/models/image.rb
@@ -40,6 +40,7 @@ module Fog
           attribute :image_type
           attribute :instance_uuid
           attribute :user_id
+          attribute :block_device_mapping
 
           def method_missing(method_sym, *arguments, &block)
             if attributes.key?(method_sym)


### PR DESCRIPTION
This PR adds `block_device_mapping` attribute to image model. When snapshotting VM that was booted from volume, image and volume snapshots are created. This property contains a snapshot_id, and it's needed for having a reference to the volume snapshot. I don't like that `block_device_mapping` will be an unparsed JSON string and that's also an array: ``` "block_device_mapping"=>
  "[{\"guest_format\": null, \"boot_index\": 0, \"delete_on_termination\": false, \"no_device\": null, \"snapshot_id\": \"94167803-1136-43f5-b2ff-1590d9bdf5f7\", \"device_name\": \"/dev/vda\", \"disk_bus\": \"virtio\", \"image_id\": null, \"source_type\": \"snapshot\", \"tag\": null, \"device_type\": \"disk\", \"volume_id\": null, \"destination_type\": \"volume\", \"volume_size\": 1}]",``` If there is a clean way to parse it in fog, I'll be happy to add it.

@aufi @gildub 