### PR TITLE
Add multiattach parameter to volume creation

### DIFF
--- a/lib/fog/openstack/volume/requests/create_volume.rb
+++ b/lib/fog/openstack/volume/requests/create_volume.rb
@@ -6,7 +6,8 @@ module Fog
 
         def _create_volume(data, options = {})
           vanilla_options = [:snapshot_id, :imageRef, :volume_type,
-                             :source_volid, :availability_zone, :metadata]
+                             :source_volid, :availability_zone, :metadata,
+                             :multiattach]
           vanilla_options.select { |o| options[o] }.each do |key|
             data['volume'][key] = options[key]
           end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1660896

@gildub What if anything do I need to do here to support older versions of Cinder that don't know about this parameter?

https://docs.openstack.org/cinder/latest/admin/blockstorage-volume-multiattach.html