### PR TITLE
Dell ECS requires the Accept header to be set to application/json, too.

### DIFF
--- a/lib/fog/openstack/auth/token.rb
+++ b/lib/fog/openstack/auth/token.rb
@@ -42,9 +42,13 @@ module Fog
         def authenticate(creds, options)
           connection = Fog::Core::Connection.new(creds[:uri].to_s, false, options)
 
-          request = {
+          headers = {
+            'Accept'       => 'application/json',
+            'Content-Type' => 'application/json'
+          }
+          options = {
             :expects => [200, 201],
-            :headers => {'Content-Type' => 'application/json'},
+            :headers => headers,
             :body    => Fog::JSON.encode(creds[:data]),
             :method  => 'POST',
             :path    => creds[:uri].path + prefix_path(creds[:uri]) + path


### PR DESCRIPTION
Validated that this now works with our Dell ECS instance. It requires the Accept header to be set to return JSON. If not It'll return XML which will result in a ParseError.