### PR TITLE
Add debugger warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,8 @@ CollectionMethods:
     reduce: inject
 CyclomaticComplexity:
   Severity: refactor
+Debugger:
+  Enabled: true
 FormatString:
   EnforcedStyle: percent
 HashSyntax:


### PR DESCRIPTION
This should help to prevent binding.pry in production.