### PR TITLE
Ensure User's Password is always String

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -172,6 +172,9 @@ module Fog
           instance_variable_set "@#{openstack_param}".to_sym, value
         end
 
+        # Ensure OpenStack User's Password is always a String
+        @openstack_api_key = @openstack_api_key.to_s if @openstack_api_key
+
         @auth_token ||= options[:openstack_auth_token]
         @openstack_must_reauthenticate = false
         @openstack_endpoint_type = options[:openstack_endpoint_type] || 'public'


### PR DESCRIPTION
When OpenStack User's password was a Number, fog-core coerced it to Numeric type, which caused
HTTP 400 failure leading to print request malformed error message including the password.

Value's coercing function from fog-core is a feature and it should not be changed propably,
so adding String cast directly to OpenStack provider.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1723180