### PR TITLE
Fix potential issue with frozen strings with openstack_endpoint_type

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -198,7 +198,7 @@ module Fog
 
         @openstack_service_type = options[:openstack_service_type] || default_service_type
         @openstack_endpoint_type = options[:openstack_endpoint_type] || default_endpoint_type
-        @openstack_endpoint_type.gsub!(/URL/, '')
+        @openstack_endpoint_type = @openstack_endpoint_type.gsub(/URL/, '')
         @connection_options = options[:connection_options] || {}
         @persistent = options[:persistent] || false
       end


### PR DESCRIPTION
It seems when using fog-openstack-1.x with Chef [1] , @openstack_endpoint_type
becomes a frozen string and fails with FrozenError. Unfortunately, I haven't
been able to reproduce this issue in unit tests but I know for a fact that this
fixes the issue. Looking through the code base, this is the only place where a
``gsub!`` is used in this manner.

Further debugging shows this stack trace which lead me to this:
```
DEBUG: FrozenError: openstack_role[service] (openstack-identity::registration line 70) had an error: FrozenError: can't modify frozen String
/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/fog-openstack-1.0.8/lib/fog/openstack/core.rb:200:in `gsub!'
/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/fog-openstack-1.0.8/lib/fog/openstack/core.rb:200:in `setup'
/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/fog-openstack-1.0.8/lib/fog/openstack/core.rb:43:in `initialize'
/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/fog-core-2.1.2/lib/fog/core/service.rb:115:in `new'
/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/fog-core-2.1.2/lib/fog/core/service.rb:115:in `new'
/tmp/kitchen/cache/cookbooks/openstackclient/libraries/openstack_base.rb:22:in `connection'
/tmp/kitchen/cache/cookbooks/openstackclient/libraries/openstack_role.rb:28:in `block in <class:OpenstackRole>' (eval):2:in `block in action_create'
```

[1] https://review.opendev.org/665827