### PR TITLE
Remove bundler pessimistic 1 version

### DIFF
--- a/fog-openstack.gemspec
+++ b/fog-openstack.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fog-json',  '>= 1.0'
   spec.add_dependency 'ipaddress', '>= 0.8'
 
-  spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency "mime-types"
   spec.add_development_dependency "mime-types-data"


### PR DESCRIPTION
Bundler ~> 1 dependency failed on certain Ruby version. Removing version requirement.