### PR TITLE
Update Orchestration Stack find by ID method

### DIFF
--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -47,6 +47,7 @@ module Fog
       request :show_resource_metadata
       request :show_resource_schema
       request :show_resource_template
+      request :show_stack
       request :show_stack_details
       request :update_stack
       request :patch_stack

--- a/lib/fog/openstack/orchestration/models/stacks.rb
+++ b/lib/fog/openstack/orchestration/models/stacks.rb
@@ -20,10 +20,11 @@ module Fog
           load_response(data, 'stacks')
         end
 
-        # Deprecated
         def find_by_id(id)
-          Fog::Logger.deprecation("#find_by_id(id) is deprecated, use #get(name, id) instead [light_black](#{caller.first})[/]")
-          find { |stack| stack.id == id }
+          data = service.show_stack(id).body['stack']
+          new(data)
+        rescue Fog::OpenStack::Orchestration::NotFound
+            nil
         end
 
         def get(arg1, arg2 = nil)

--- a/lib/fog/openstack/orchestration/requests/show_stack.rb
+++ b/lib/fog/openstack/orchestration/requests/show_stack.rb
@@ -1,0 +1,26 @@
+module Fog
+    module OpenStack
+      class Orchestration
+        class Real
+          def show_stack(id)
+            request(
+              :method  => 'GET',
+              :path    => "stacks/#{id}",
+              :expects => 200
+            )
+          end
+        end
+
+        class Mock
+          def show_stack(_id)
+            stack = data[:stack].values
+
+            Excon::Response.new(
+              :body   => {'stack' => stack},
+              :status => 200
+            )
+          end
+        end
+      end
+    end
+  end


### PR DESCRIPTION
If searching in all Stacks including nested ones is needed, it is necessary
use find Stack by ID as the only argument.

Heat API supports this call [1]. Updating current find_by_id method to
use this API call and making it not-deprecated.

Related to https://github.com/ManageIQ/manageiq-providers-openstack/pull/487

[1] https://docs.openstack.org/api-ref/orchestration/v1/?expanded=find-stack-detail,show-stack-details-detail#find-stack