### PR TITLE
openstack::core: Don't mutate params between request retries

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -54,7 +54,7 @@ module Fog
 
           response = @connection.request(
             params.merge(
-              :headers => headers(params.delete(:headers)),
+              :headers => headers(params[:headers]),
               :path    => "#{@path}/#{params[:path]}"
             )
           )


### PR DESCRIPTION
This PR fixes #507 and potentially #501 and #502 

Since f72d2fc (first released in v0.1.20) fog-openstack mutates the
params passed on `Fog::Openstack::Core#request` by calling
`#delete(:headers)`[1] on the params hash to access it.

In case of a re-authentication the request is re-issued[2] but the
headers hash is no longer present. As a result all headers passed by the
user are lost and the request gets just the default headers[3].

This commit fixes the aforementioned behavior by not mutating the params
hash in order to access its `:headers` part.

[1]: https://github.com/fog/fog-openstack/blob/v1.0.10/lib/fog/openstack/core.rb#L57
[2]: https://github.com/fog/fog-openstack/blob/v1.0.10/lib/fog/openstack/core.rb#L61
[3]: https://github.com/fog/fog-openstack/blob/v1.0.10/lib/fog/openstack/core.rb#L128