### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,27 @@ matrix:
     gemfile: Gemfile
   - rvm: jruby-head
     gemfile: Gemfile
+ # ppc64le related code
+  - rvm: 2.3.8
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: 2.4.5
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: 2.5.3
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: 2.6.0
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: jruby-head
+    arch: ppc64le
+    gemfile: Gemfile
+  
   allow_failures:
   - rvm: jruby-head
+  - rvm: jruby-head
+    arch: ppc64le
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/fog-openstack/builds/209015796