### PR TITLE
Remove ipaddress dependency

### DIFF
--- a/fog-openstack.gemspec
+++ b/fog-openstack.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fog-core',  '~> 2.1'
   spec.add_dependency 'fog-json',  '>= 1.0'
-  spec.add_dependency 'ipaddress', '>= 0.8'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
In 118a99282e1225db8735f5547280788ede97a09e this was added, but I can't find any place that it would be used.