### PR TITLE
Add partial support for ruby 3 / 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+/tags
 /_yardoc/
 /coverage/
 /doc/

--- a/lib/fog/openstack/compute/requests/delete_service.rb
+++ b/lib/fog/openstack/compute/requests/delete_service.rb
@@ -4,7 +4,7 @@ module Fog
       class Real
         def delete_service(uuid, optional_params = nil)
           # Encode all params
-          optional_params = optional_params.each { |k, v| optional_params[k] = URI.encode(v) } if optional_params
+          optional_params = optional_params.each { |k, v| optional_params[k] = CGI.escape(v) } if optional_params
 
           request(
             :expects => [202, 204],

--- a/lib/fog/openstack/compute/requests/disable_service.rb
+++ b/lib/fog/openstack/compute/requests/disable_service.rb
@@ -6,7 +6,7 @@ module Fog
           data = {"host" => host, "binary" => binary}
 
           # Encode all params
-          optional_params = optional_params.each { |k, v| optional_params[k] = URI.encode(v) } if optional_params
+          optional_params = optional_params.each { |k, v| optional_params[k] = CGI.escape(v) } if optional_params
 
           request(
             :body    => Fog::JSON.encode(data),

--- a/lib/fog/openstack/compute/requests/disable_service_log_reason.rb
+++ b/lib/fog/openstack/compute/requests/disable_service_log_reason.rb
@@ -6,7 +6,7 @@ module Fog
           data = {"host" => host, "binary" => binary, "disabled_reason" => disabled_reason}
 
           # Encode all params
-          optional_params = optional_params.each { |k, v| optional_params[k] = URI.encode(v) } if optional_params
+          optional_params = optional_params.each { |k, v| optional_params[k] = CGI.escape(v) } if optional_params
 
           request(
             :body    => Fog::JSON.encode(data),

--- a/lib/fog/openstack/compute/requests/enable_service.rb
+++ b/lib/fog/openstack/compute/requests/enable_service.rb
@@ -6,7 +6,7 @@ module Fog
           data = {"host" => host, "binary" => binary}
 
           # Encode all params
-          optional_params = optional_params.each { |k, v| optional_params[k] = URI.encode(v) } if optional_params
+          optional_params = optional_params.each { |k, v| optional_params[k] = CGI.escape(v) } if optional_params
 
           request(
             :body    => Fog::JSON.encode(data),

--- a/lib/fog/openstack/storage/requests/delete_multiple_objects.rb
+++ b/lib/fog/openstack/storage/requests/delete_multiple_objects.rb
@@ -45,7 +45,7 @@ module Fog
         def delete_multiple_objects(container, object_names, options = {})
           body = object_names.map do |name|
             object_name = container ? "#{container}/#{name}" : name
-            URI.encode(object_name)
+            CGI.escapeS(object_name)
           end.join("\n")
 
           response = request({

--- a/lib/fog/openstack/storage/requests/delete_multiple_objects.rb
+++ b/lib/fog/openstack/storage/requests/delete_multiple_objects.rb
@@ -45,7 +45,7 @@ module Fog
         def delete_multiple_objects(container, object_names, options = {})
           body = object_names.map do |name|
             object_name = container ? "#{container}/#{name}" : name
-            CGI.escapeS(object_name)
+            CGI.escape(object_name)
           end.join("\n")
 
           response = request({

--- a/lib/fog/openstack/workflow/v2/requests/delete_action.rb
+++ b/lib/fog/openstack/workflow/v2/requests/delete_action.rb
@@ -7,7 +7,7 @@ module Fog
             request(
               :expects => 204,
               :method  => "DELETE",
-              :path    => "actions/#{URI.encode(name)}"
+              :path    => "actions/#{CGI.escape(name)}"
             )
           end
         end

--- a/lib/fog/openstack/workflow/v2/requests/delete_cron_trigger.rb
+++ b/lib/fog/openstack/workflow/v2/requests/delete_cron_trigger.rb
@@ -7,7 +7,7 @@ module Fog
             request(
               :expects => 204,
               :method  => "DELETE",
-              :path    => "cron_triggers/#{URI.encode(name)}"
+              :path    => "cron_triggers/#{CGI.escape(name)}"
             )
           end
         end

--- a/lib/fog/openstack/workflow/v2/requests/delete_environment.rb
+++ b/lib/fog/openstack/workflow/v2/requests/delete_environment.rb
@@ -7,7 +7,7 @@ module Fog
             request(
               :expects => 204,
               :method  => "DELETE",
-              :path    => "environments/#{URI.encode(name)}"
+              :path    => "environments/#{CGI.escape(name)}"
             )
           end
         end

--- a/lib/fog/openstack/workflow/v2/requests/delete_workbook.rb
+++ b/lib/fog/openstack/workflow/v2/requests/delete_workbook.rb
@@ -7,7 +7,7 @@ module Fog
             request(
               :expects => 204,
               :method  => "DELETE",
-              :path    => "workbooks/#{URI.encode(name)}"
+              :path    => "workbooks/#{CGI.escape(name)}"
             )
           end
         end

--- a/lib/fog/openstack/workflow/v2/requests/get_action.rb
+++ b/lib/fog/openstack/workflow/v2/requests/get_action.rb
@@ -7,7 +7,7 @@ module Fog
             request(
               :expects => 200,
               :method  => "GET",
-              :path    => "actions/#{URI.encode(name)}"
+              :path    => "actions/#{CGI.escape(name)}"
             )
           end
         end

--- a/lib/fog/openstack/workflow/v2/requests/get_cron_trigger.rb
+++ b/lib/fog/openstack/workflow/v2/requests/get_cron_trigger.rb
@@ -7,7 +7,7 @@ module Fog
             request(
               :expects => 200,
               :method  => "GET",
-              :path    => "cron_triggers/#{URI.encode(name)}"
+              :path    => "cron_triggers/#{CGI.escape(name)}"
             )
           end
         end

--- a/lib/fog/openstack/workflow/v2/requests/get_environment.rb
+++ b/lib/fog/openstack/workflow/v2/requests/get_environment.rb
@@ -7,7 +7,7 @@ module Fog
             request(
               :expects => 200,
               :method  => "GET",
-              :path    => "environments/#{URI.encode(name)}"
+              :path    => "environments/#{CGI.escape(name)}"
             )
           end
         end

--- a/lib/fog/openstack/workflow/v2/requests/get_workbook.rb
+++ b/lib/fog/openstack/workflow/v2/requests/get_workbook.rb
@@ -7,7 +7,7 @@ module Fog
             request(
               :expects => 200,
               :method  => "GET",
-              :path    => "workbooks/#{URI.encode(name)}"
+              :path    => "workbooks/#{CGI.escape(name)}"
             )
           end
         end


### PR DESCRIPTION
This basically replaces all `URI.encode` occurences with `CGI.escape`

As the maintainer of [activestorage-openstack](https://github.com/chaadow/activestorage-openstack).   this has made my [test suite](https://github.com/chaadow/activestorage-openstack/actions/runs/3211049861) pass both on ruby `3.0` and `3.1` so the change should be enough for the storage component

It would be much appreciated if a release is made with this PR merged 🙏🏼 

Fixes #522 