### PR TITLE
Delete newlines in base64 encoding

### DIFF
--- a/lib/fog/openstack/compute/models/server.rb
+++ b/lib/fog/openstack/compute/models/server.rb
@@ -87,7 +87,7 @@ module Fog
         end
 
         def user_data=(ascii_userdata)
-          self.user_data_encoded = [ascii_userdata].pack('m') if ascii_userdata
+          self.user_data_encoded = [ascii_userdata].pack('m0') if ascii_userdata
         end
 
         def destroy


### PR DESCRIPTION
Bosh Openstack cpi uses a  POST request for instance creation, with body content `user_data` base64 encoded row containing newlines `\n` every 60 characters:

```
body: {
  "server": {
    "flavorRef": "s3.small.1",
    "name": "vm-d35f15af-9840-44be-8d95-a2b1e1ad5358",
    "imageRef": "97727138-8334-4188-9b1e-4x558599d99b",
    "user_data": "eyJzZXJ2ZXIiOnsibmFtZSI6InZtLWQzNWYxNWFmLTk4NDAtNDRiZS04ZDk1\nLWEyYjFlMWFkNTM1OCJ9LCJuZXR3b3JrcyI6eyJ0Zi1uZXQtY29hYi1kZXBs\ncy1pb
```
Recent upgrade (openstack 22.3) is less permissive for base64 decoding and refuses newlines `\n` inside base64 encoded value.

Reference: https://github.com/cloudfoundry/bosh-openstack-cpi-release/issues/255