### PR TITLE
Expose :openstack_user_domain_name

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -14,7 +14,7 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version
+                 :openstack_identity_api_version, :openstack_user_domain_name
 
       ## MODELS
       #


### PR DESCRIPTION
When talking to keystone v3, you need to pass in `:openstack_user_domain_name`. It is used,  https://github.com/fog/fog-openstack/blob/master/lib/fog/openstack/auth/token/v3.rb#L103 And passing it works, albeit with a warning

	[fog][WARNING] Unrecognized arguments: openstack_user_domain_name