### PR TITLE
Add application_credential params to Storage class

### DIFF
--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_project_name, :openstack_project_id, :openstack_cache_ttl,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_api_version, :openstack_temp_url_key
+                 :openstack_identity_api_version, :openstack_temp_url_key,
+                 :openstack_application_credential_id, :openstack_application_credential_secret
 
       model_path 'fog/openstack/storage/models'
       model       :directory


### PR DESCRIPTION
* Swift supports application credentials: https://github.com/restic/restic/pull/2156
* see also https://github.com/fog/fog-openstack/pull/533