### PR TITLE
Update namespace for RecursiveHotFileLoader in OpenStack Orchestration

### DIFF
--- a/lib/fog/openstack/orchestration/requests/create_stack.rb
+++ b/lib/fog/openstack/orchestration/requests/create_stack.rb
@@ -37,7 +37,7 @@ module Fog
           #  and replaces it with :template.
           #  see https://github.com/openstack-infra/shade/blob/master/shade/openstackcloud.py#L1201
           #  see https://developer.openstack.org/api-ref/orchestration/v1/index.html#create-stack
-          file_resolver = Util::RecursiveHotFileLoader.new(options[:template] || options[:template_url], options[:files])
+          file_resolver = OrchestrationUtil::RecursiveHotFileLoader.new(options[:template] || options[:template_url], options[:files])
           options[:template] = file_resolver.template
           options[:files] = file_resolver.files unless file_resolver.files.empty?
 


### PR DESCRIPTION
   ### Problem:
   When attempting to create a stack in OpenStack using ManageIQ, the following error occurs:

   ```
   uninitialized constant Fog::OpenStack::Orchestration::Real::Util
   ```

   This issue is caused by a module naming mismatch in the `fog-openstack` gem.

   ### Root Cause:
   The code references `Util::RecursiveHotFileLoader`, but the correct namespace is `OrchestrationUtil::RecursiveHotFileLoader`.

   ### Fix:
   - Updated `create_stack.rb` to use `OrchestrationUtil::RecursiveHotFileLoader` instead of `Util::RecursiveHotFileLoader`.

   This resolves the issue and ensures proper stack creation.

